### PR TITLE
Fail build on compiler warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:all" << "-Werror"
+    options.compilerArgs << "-Xlint:all,-serial,-unchecked,-deprecation" << "-Werror"
 }
 
 jacocoTestCoverageVerification {
@@ -154,8 +154,8 @@ project.test {
 
     beforeTest { TestDescriptor td -> outputCache.clear() }
 
-    onOutput { 
-        TestDescriptor td, TestOutputEvent toe ->   
+    onOutput {
+        TestDescriptor td, TestOutputEvent toe ->
             outputCache.add(toe.getMessage())
             while (outputCache.size() > 1000) outputCache.remove()
     }
@@ -169,7 +169,7 @@ project.test {
         showStandardStreams false
     }
 
-    afterTest { 
+    afterTest {
         TestDescriptor td, TestResult tr ->
             if (tr.resultType == TestResult.ResultType.FAILURE) {
                 println()

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ version: "0.17.0"
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:all,-serial,-deprecation" << "-Werror"
+    options.compilerArgs << "-Xlint:all,-serial" << "-Werror"
 }
 
 jacocoTestCoverageVerification {

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ version: "0.17.0"
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:all,-serial,-unchecked,-deprecation" << "-Werror"
+    options.compilerArgs << "-Xlint:all,-serial,-deprecation" << "-Werror"
 }
 
 jacocoTestCoverageVerification {

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,10 @@ dependencies {
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:all" << "-Werror"
+}
+
 jacocoTestCoverageVerification {
     violationRules {
         rule {

--- a/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/ArchitectureDataStructureObjectMapper.java
+++ b/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/ArchitectureDataStructureObjectMapper.java
@@ -16,7 +16,9 @@ import java.util.Set;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static com.fasterxml.jackson.annotation.PropertyAccessor.*;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.FIELD;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.GETTER;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.IS_GETTER;
 
 public class ArchitectureDataStructureObjectMapper {
     private final ObjectMapper mapper;

--- a/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/SetSerializer.java
+++ b/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/SetSerializer.java
@@ -9,13 +9,14 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-public class SetSerializer extends StdSerializer<Set> {
+public class SetSerializer extends StdSerializer<Set<?>> {
+    @SuppressWarnings({"rawtypes", "unchecked"})
     public SetSerializer(Class<Set> t) {
-        super(t);
+        super((Class) t);
     }
 
     @Override
-    public void serialize(Set set, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    public void serialize(Set<?> set, JsonGenerator gen, SerializerProvider provider) throws IOException {
         if (set == null) {
             gen.writeNull();
             return;
@@ -29,7 +30,7 @@ public class SetSerializer extends StdSerializer<Set> {
 
                 // SortedSet elements must implement the Comparable interface
                 if (Comparable.class.isAssignableFrom(item.getClass())) {
-                    set = new TreeSet(set);
+                    set = new TreeSet<>(set);
                 }
             }
 

--- a/src/main/java/net/trilogy/arch/adapter/git/GitInterface.java
+++ b/src/main/java/net/trilogy/arch/adapter/git/GitInterface.java
@@ -113,6 +113,6 @@ public class GitInterface {
         return dir.toPath().toAbsolutePath().toFile();
     }
 
-    public class BranchNotFoundException extends Exception {
+    public static class BranchNotFoundException extends Exception {
     }
 }

--- a/src/main/java/net/trilogy/arch/adapter/structurizr/StructurizrViewsMapper.java
+++ b/src/main/java/net/trilogy/arch/adapter/structurizr/StructurizrViewsMapper.java
@@ -95,7 +95,7 @@ public class StructurizrViewsMapper {
         }
     }
 
-    private Method findSetter(Class model, Object objectToSet, String methodName) {
+    private Method findSetter(Class<?> model, Object objectToSet, String methodName) {
         try {
             return model.getDeclaredMethod(methodName, objectToSet.getClass());
         } catch (NoSuchMethodException e) {

--- a/src/main/java/net/trilogy/arch/schema/SchemaValidator.java
+++ b/src/main/java/net/trilogy/arch/schema/SchemaValidator.java
@@ -36,7 +36,9 @@ public class SchemaValidator {
         return errors;
     }
 
+    @SuppressWarnings("deprecation")
     private JsonSchema getJsonSchemaFromClasspath(String schemaResource) {
+        // TODO: See if Jackson has a non-deprecated means of doing this
         JsonSchemaFactory factory = JsonSchemaFactory.getInstance();
         InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(schemaResource);
         return factory.getSchema(is);

--- a/src/main/java/net/trilogy/arch/validation/ArchitectureDataStructureValidator.java
+++ b/src/main/java/net/trilogy/arch/validation/ArchitectureDataStructureValidator.java
@@ -13,6 +13,7 @@ import java.util.List;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.stream.Collectors.toList;
 
+@SuppressWarnings("deprecation") // ArchitectureDataStructureReader
 public class ArchitectureDataStructureValidator {
     private final List<DataStructureValidator> dataStructureDataStructureValidators;
     private final SchemaValidator schemaValidator;

--- a/src/main/java/net/trilogy/arch/validation/ArchitectureDataStructureValidatorFactory.java
+++ b/src/main/java/net/trilogy/arch/validation/ArchitectureDataStructureValidatorFactory.java
@@ -6,7 +6,7 @@ import net.trilogy.arch.facade.FilesFacade;
 import net.trilogy.arch.schema.SchemaValidator;
 
 public abstract class ArchitectureDataStructureValidatorFactory {
-
+    @SuppressWarnings("deprecation")
     public static ArchitectureDataStructureValidator create() {
         return new ArchitectureDataStructureValidator(
                 ImmutableList.of(

--- a/src/test/java/net/trilogy/arch/adapter/jira/JiraApiTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/jira/JiraApiTest.java
@@ -47,7 +47,7 @@ public class JiraApiTest {
     @Test
     public void shouldMakeRequestToGetJiraStory() throws Exception {
         // GIVEN:
-        final var mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.body()).thenReturn(loadResource(getClass(), JSON_JIRA_GET_EPIC));
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
         final Jira jiraToQuery = new Jira("JIRA-TICKET-123", "http://link");
@@ -85,7 +85,7 @@ public class JiraApiTest {
     @Test
     public void shouldParseResponseWhenGetJiraStory() throws Exception {
         // GIVEN:
-        @SuppressWarnings("rawtypes") HttpResponse mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.body()).thenReturn(loadResource(getClass(), JSON_JIRA_GET_EPIC));
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
 
@@ -97,7 +97,7 @@ public class JiraApiTest {
 
     @Test
     public void shouldThrowPresentableExceptionIfCreateStoryFails() throws Exception {
-        var mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.body()).thenReturn(loadResource(getClass(), JSON_STRUCTURIZR_BIG_BANK)); // <-- this is the wrong response
         when(mockedResponse.statusCode()).thenReturn(201);
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
@@ -115,9 +115,14 @@ public class JiraApiTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private static HttpResponse<Object> mockedGenericHttpResponse() {
+        return (HttpResponse<Object>) mock(HttpResponse.class);
+    }
+
     @Test
     public void shouldThrowPresentableExceptionIfGetStoryFails() throws Exception {
-        @SuppressWarnings("rawtypes") HttpResponse mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.body()).thenReturn(loadResource(getClass(), JSON_STRUCTURIZR_BIG_BANK)); // <-- this is the wrong response
         when(mockedResponse.statusCode()).thenReturn(200);
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
@@ -138,7 +143,7 @@ public class JiraApiTest {
     @Test
     public void shouldThrowProperExceptionIfGetStoryNotFound() throws Exception {
         // GIVEN:
-        HttpResponse<Object> mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.statusCode()).thenReturn(404); // not found
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
 
@@ -158,7 +163,7 @@ public class JiraApiTest {
     @Test
     public void shouldThrowProperExceptionIfUnauthorizedForCreateStory() throws Exception {
         // GIVEN:
-        HttpResponse<Object> mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.statusCode()).thenReturn(401); // unauthorized
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
 
@@ -178,7 +183,7 @@ public class JiraApiTest {
     @Test
     public void shouldThrowProperExceptionIfUnauthorizedForGetStory() throws Exception {
         // GIVEN:
-        HttpResponse<Object> mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.statusCode()).thenReturn(401); // unauthorized
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
 
@@ -197,7 +202,7 @@ public class JiraApiTest {
 
     @Test
     public void shouldParseJiraResponseOfCreateStories() throws Exception {
-        HttpResponse<Object> mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.statusCode()).thenReturn(201);
         when(mockedResponse.body()).thenReturn(TestHelper.loadResource(getClass(), JSON_JIRA_CREATE_STORIES_RESPONSE_EXPECTED_BODY));
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
@@ -222,7 +227,7 @@ public class JiraApiTest {
     public void shouldMakeCreateStoryRequestWithCorrectBody() throws Exception {
         // GIVEN:
         List<JiraStory> sampleJiraStories = createSampleJiraStories();
-        var mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.statusCode()).thenReturn(201);
         when(mockedResponse.body()).thenReturn(TestHelper.loadResource(getClass(), JSON_JIRA_CREATE_STORIES_RESPONSE_EXPECTED_BODY));
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
@@ -283,7 +288,7 @@ public class JiraApiTest {
                 new JiraStory("STORY TITLE 2", List.of(jiraTdd1, jiraTdd2), List.of(jiraFunctionalRequirement1, jiraFunctionalRequirement2))
         );
 
-        var mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.statusCode()).thenReturn(201);
         when(mockedResponse.body()).thenReturn(TestHelper.loadResource(getClass(), JSON_JIRA_CREATE_STORIES_RESPONSE_EXPECTED_BODY));
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
@@ -307,7 +312,7 @@ public class JiraApiTest {
     @Test
     public void shouldMakeCreateStoryRequestWithCorrectHeaders() throws Exception {
         // GIVEN:
-        var mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mockedGenericHttpResponse();
         when(mockedResponse.statusCode()).thenReturn(201);
         when(mockedResponse.body()).thenReturn(TestHelper.loadResource(getClass(), JSON_JIRA_CREATE_STORIES_RESPONSE_EXPECTED_BODY));
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);

--- a/src/test/java/net/trilogy/arch/adapter/jira/JiraApiTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/jira/JiraApiTest.java
@@ -47,7 +47,7 @@ public class JiraApiTest {
     @Test
     public void shouldMakeRequestToGetJiraStory() throws Exception {
         // GIVEN:
-        @SuppressWarnings("rawtypes") HttpResponse mockedResponse = mock(HttpResponse.class);
+        final var mockedResponse = mock(HttpResponse.class);
         when(mockedResponse.body()).thenReturn(loadResource(getClass(), JSON_JIRA_GET_EPIC));
         when(mockHttpClient.send(any(), any())).thenReturn(mockedResponse);
         final Jira jiraToQuery = new Jira("JIRA-TICKET-123", "http://link");

--- a/src/test/java/net/trilogy/arch/domain/ArchitectureDataStructureReaderTest.java
+++ b/src/test/java/net/trilogy/arch/domain/ArchitectureDataStructureReaderTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@SuppressWarnings("deprecation")
 public class ArchitectureDataStructureReaderTest {
     @Test
     public void shouldReadMetaData() throws Exception {

--- a/src/test/java/net/trilogy/arch/e2e/IdGenerationTest.java
+++ b/src/test/java/net/trilogy/arch/e2e/IdGenerationTest.java
@@ -73,6 +73,7 @@ public class IdGenerationTest {
         });
     }
 
+    @SuppressWarnings("deprecation")
     private ArchitectureDataStructure getDataStructure() throws IOException {
         File documentationRoot = new File(getClass().getResource(TestHelper.ROOT_PATH_TO_TEST_PRODUCT_DOCUMENTATION).getPath());
         File manifestFile = new File(documentationRoot + File.separator + "product-architecture.yml");

--- a/src/test/java/net/trilogy/arch/integration/ParsedYamlToModelIntegrationTest.java
+++ b/src/test/java/net/trilogy/arch/integration/ParsedYamlToModelIntegrationTest.java
@@ -350,6 +350,7 @@ public class ParsedYamlToModelIntegrationTest {
         assertEquals(component.getTechnology(), "Spring MVC Rest Controller");
     }
 
+    @SuppressWarnings("deprecation")
     private Workspace getWorkspace() throws IOException {
         File documentationRoot = new File(getClass().getResource(TestHelper.ROOT_PATH_TO_TEST_PRODUCT_DOCUMENTATION).getPath());
         File manifestFile = new File(documentationRoot + File.separator + "product-architecture.yml");

--- a/src/test/java/net/trilogy/arch/transformation/enhancer/DecisionEnhancerTest.java
+++ b/src/test/java/net/trilogy/arch/transformation/enhancer/DecisionEnhancerTest.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import static com.google.common.collect.ImmutableList.of;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,7 +26,7 @@ public class DecisionEnhancerTest {
 
         new DecisionEnhancer().enhance(workspace, dataStructure);
 
-        assertThat(workspace.getDocumentation().getDecisions(), hasSize(0));
+        assertEquals(workspace.getDocumentation().getDecisions().size(), 0);
     }
 
     @Test
@@ -37,7 +38,7 @@ public class DecisionEnhancerTest {
 
         new DecisionEnhancer().enhance(workspace, dataStructure);
 
-        assertThat(workspace.getDocumentation().getDecisions(), hasSize(1));
+        assertEquals(workspace.getDocumentation().getDecisions().size(), 1);
     }
 
     @Test
@@ -53,6 +54,6 @@ public class DecisionEnhancerTest {
 
         new DecisionEnhancer().enhance(workspace, dataStructure);
 
-        assertThat(workspace.getDocumentation().getDecisions(), hasSize(2));
+        assertEquals(workspace.getDocumentation().getDecisions().size(), 2);
     }
 }

--- a/src/test/java/net/trilogy/arch/transformation/enhancer/DocumentationEnhancerTest.java
+++ b/src/test/java/net/trilogy/arch/transformation/enhancer/DocumentationEnhancerTest.java
@@ -15,6 +15,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -109,16 +111,22 @@ public class DocumentationEnhancerTest {
     @Test
     public void shouldAddDocumentationImages() {
         // Given
-        Workspace workspace = new Workspace("Foo", "Bar");
-        final String file = getClass().getResource(ROOT_PATH_TO_TEST_PRODUCT_DOCUMENTATION).getFile();
+        final var workspace = new Workspace("Foo", "Bar");
+        final var file = getClass().getResource(ROOT_PATH_TO_TEST_PRODUCT_DOCUMENTATION).getFile();
 
         // When
         new DocumentationEnhancer(new File(file), new FilesFacade()).enhance(workspace, new ArchitectureDataStructure());
 
         // Then
-        Set<Image> images = workspace.getDocumentation().getImages();
+        final Set<Image> images = workspace.getDocumentation().getImages();
         collector.checkThat(images.size(), equalTo(1));
-        Image image = (Image) new ArrayList(images).get(0);
+        final Image image = first(images);
         collector.checkThat(image.getName(), equalTo("devfactory.png"));
+    }
+
+    private static <T> T first(final Collection<T> first) {
+        final Iterator<T> it = first.iterator();
+        if (!it.hasNext()) throw new IllegalStateException("No first element");
+        return it.next();
     }
 }


### PR DESCRIPTION
What it says on the tin.

Workarounds:
- At individual spots, particularly tests, suppress specific warnings.  Consider these "TODOs" for improving those code spots
- Ignore serialization warnings globally.  I've not seen evidence the code base uses Java serialization features
