### PR TITLE
Use more recent tool for executable jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 plugins {
     id "info.solidsoft.pitest" version "1.5.2"
     id "com.github.ben-manes.versions" version "0.29.0"
+    id "org.springframework.boot" version "2.3.3.RELEASE"
 }
 
 apply plugin: "java"
@@ -181,17 +182,6 @@ project.test {
     }
 }
 
-
-jar {
-    manifest {
-        attributes "Main-Class": "net.trilogy.arch.Application", "Multi-Release": true
-    }
-
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    } {
-        exclude "META-INF/*.SF"
-        exclude "META-INF/*.DSA"
-        exclude "META-INF/*.RSA"
-    }
+bootJar {
+    mainClassName = "net.trilogy.arch.Application"
 }


### PR DESCRIPTION
```
🌼 ./gradlew clean build  # output omitted
🌼 java -jar build/libs/arch-as-code-0.1.6.jar -h
Usage: arch-as-code [-hV] [COMMAND]
Architecture as code
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  init                     Initializes a new workspace directory to contain a
                             single project architecture, AUs, documentation,
                             and credentials for Structurizr imports and
                             exports. This is generally the first command to be
                             run.
  validate                 Validate a product's architecture
  publish                  Publish architecture to structurizr.
  import                   Imports existing structurizr workspace, overwriting
                             the existing product architecture.
  list-components          Outputs a CSV formatted list of components and their
                             IDs, which are present in the architecture.
  diff                     Display the diff between product architecture in
                             current branch and specified branch.
  architecture-update, au  Namespace for Architecture Update commands.
```