### PR TITLE
Intellij formatting

### DIFF
--- a/src/main/java/net/trilogy/arch/Application.java
+++ b/src/main/java/net/trilogy/arch/Application.java
@@ -46,6 +46,18 @@ public class Application {
     @Builder.Default
     private final GraphvizInterface graphvizInterface = new GraphvizInterface();
 
+    public static void main(String[] args) {
+        final var app = Application.builder().build();
+
+        int exitCode = app.execute(args);
+
+        if (exitCode != 0) {
+            app.getCli().getCommandSpec().commandLine().getOut().println("Command failed, for more info please check log file at: " + System.getProperty("user.home") +
+                    "/.arch-as-code/arch-as-code.log");
+        }
+        exit(exitCode);
+    }
+
     private CommandLine getCli() {
         return new CommandLine(new ParentCommand())
                 .addSubcommand(new InitializeCommand(filesFacade))
@@ -62,18 +74,6 @@ public class Application {
                                 .addSubcommand(new AuPublishStoriesCommand(jiraApiFactory, filesFacade, gitInterface))
                                 .addSubcommand(new AuAnnotateCommand(filesFacade))
                 );
-    }
-
-    public static void main(String[] args) {
-        final var app = Application.builder().build();
-
-        int exitCode = app.execute(args);
-
-        if (exitCode != 0) {
-            app.getCli().getCommandSpec().commandLine().getOut().println("Command failed, for more info please check log file at: " + System.getProperty("user.home") +
-                    "/.arch-as-code/arch-as-code.log");
-        }
-        exit(exitCode);
     }
 
     public int execute(String[] args) {

--- a/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/ArchitectureDataStructureReader.java
+++ b/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/ArchitectureDataStructureReader.java
@@ -7,21 +7,21 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * This class is being strangle-patterned away.
- * Use {@link net.trilogy.arch.adapter.architectureDataStructure.ArchitectureDataStructureObjectMapper }
+ * This class is being strangle-patterned away. Use {@link
+ * net.trilogy.arch.adapter.architectureDataStructure.ArchitectureDataStructureObjectMapper
+ * }
  */
 @Deprecated
 public class ArchitectureDataStructureReader {
 
     final private FilesFacade filesFacade;
 
-    public ArchitectureDataStructure load(File manifest) throws IOException {
-        final String archAsString = filesFacade.readString(manifest.toPath());
-        return new ArchitectureDataStructureObjectMapper().readValue(archAsString);
-    }
-
     public ArchitectureDataStructureReader(FilesFacade filesFacade) {
         this.filesFacade = filesFacade;
     }
 
+    public ArchitectureDataStructure load(File manifest) throws IOException {
+        final String archAsString = filesFacade.readString(manifest.toPath());
+        return new ArchitectureDataStructureObjectMapper().readValue(archAsString);
+    }
 }

--- a/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/ArchitectureDataStructureWriter.java
+++ b/src/main/java/net/trilogy/arch/adapter/architectureDataStructure/ArchitectureDataStructureWriter.java
@@ -32,7 +32,8 @@ public class ArchitectureDataStructureWriter {
         filesFacade.writeString(writeFile.toPath(), mapper.writeValueAsString(dataStructure));
 
         final Path writePath = Path.of(writeFile.getParent()).resolve("documentation");
-        if (!writePath.toFile().exists()) filesFacade.createDirectory(writePath);
+        if (!writePath.toFile().exists())
+            filesFacade.createDirectory(writePath);
 
         writeDocumentation(dataStructure, writePath);
         writeDocumentationImages(filesFacade, dataStructure, writePath);

--- a/src/main/java/net/trilogy/arch/adapter/architectureUpdate/ArchitectureUpdateObjectMapper.java
+++ b/src/main/java/net/trilogy/arch/adapter/architectureUpdate/ArchitectureUpdateObjectMapper.java
@@ -12,7 +12,9 @@ import java.io.IOException;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
-import static com.fasterxml.jackson.annotation.PropertyAccessor.*;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.FIELD;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.GETTER;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.IS_GETTER;
 
 public class ArchitectureUpdateObjectMapper {
     private final ObjectMapper mapper;

--- a/src/main/java/net/trilogy/arch/adapter/git/GitInterface.java
+++ b/src/main/java/net/trilogy/arch/adapter/git/GitInterface.java
@@ -28,6 +28,10 @@ public class GitInterface {
         this.objMapper = objMapper;
     }
 
+    private static File toAbsolute(File dir) {
+        return dir.toPath().toAbsolutePath().toFile();
+    }
+
     public ArchitectureDataStructure load(String commitReference, Path architectureYamlFilePath)
             throws IOException, GitAPIException, BranchNotFoundException {
 
@@ -46,14 +50,14 @@ public class GitInterface {
             throw new BranchNotFoundException();
         }
 
-        if(!isAnnotatedTag(git, objId)){
+        if (!isAnnotatedTag(git, objId)) {
             return git.log().add(objId).call().iterator().next();
         }
 
         var realObjId = git.getRepository()
-                        .getRefDatabase()
-                        .peel(git.getRepository().getRefDatabase().findRef(commitReference))
-                        .getPeeledObjectId();
+                .getRefDatabase()
+                .peel(git.getRepository().getRefDatabase().findRef(commitReference))
+                .getPeeledObjectId();
 
         return git.log().add(realObjId).call().iterator().next();
     }
@@ -70,12 +74,12 @@ public class GitInterface {
 
     private String getRelativePath(Path architectureYamlFilePath, Git git) {
         var repoDirAbsolutePath = git.getRepository()
-            .getDirectory()
-            .getParentFile()
-            .toPath()
-            .toAbsolutePath() 
-            .normalize()
-            .toString();
+                .getDirectory()
+                .getParentFile()
+                .toPath()
+                .toAbsolutePath()
+                .normalize()
+                .toString();
         return architectureYamlFilePath
                 .toAbsolutePath()
                 .normalize()
@@ -105,10 +109,6 @@ public class GitInterface {
                         .findGitDir(toAbsolute(dir))
                         .build()
         );
-    }
-
-    private static File toAbsolute(File dir) {
-        return dir.toPath().toAbsolutePath().toFile();
     }
 
     public static class BranchNotFoundException extends Exception {

--- a/src/main/java/net/trilogy/arch/adapter/google/GoogleDocsApiInterface.java
+++ b/src/main/java/net/trilogy/arch/adapter/google/GoogleDocsApiInterface.java
@@ -15,8 +15,18 @@ public class GoogleDocsApiInterface {
     private static final Pattern pattern = Pattern.compile("/document/d/([^/]+)");
     private final Docs api;
 
-    public GoogleDocsApiInterface(Docs rawGoogleDocsApi){
+    public GoogleDocsApiInterface(Docs rawGoogleDocsApi) {
         this.api = rawGoogleDocsApi;
+    }
+
+    private static String getDocumentId(String documentUrl) {
+        Matcher matcher = pattern.matcher(documentUrl);
+
+        if (!matcher.find()) {
+            throw new InvalidUrlException();
+        }
+
+        return matcher.group(1);
     }
 
     public Response fetch(String url) throws IOException {
@@ -34,16 +44,6 @@ public class GoogleDocsApiInterface {
         final JsonNode jsonNode = mapper.readValue(jsonString, JsonNode.class);
 
         return new Response(jsonNode, doc);
-    }
-
-    private static String getDocumentId(String documentUrl) {
-        Matcher matcher = pattern.matcher(documentUrl);
-
-        if (!matcher.find()) {
-            throw new InvalidUrlException();
-        }
-
-        return matcher.group(1);
     }
 
     public static class Response {
@@ -64,5 +64,6 @@ public class GoogleDocsApiInterface {
         }
     }
 
-    static class InvalidUrlException extends RuntimeException {}
+    static class InvalidUrlException extends RuntimeException {
+    }
 }

--- a/src/main/java/net/trilogy/arch/adapter/graphviz/GraphvizInterface.java
+++ b/src/main/java/net/trilogy/arch/adapter/graphviz/GraphvizInterface.java
@@ -1,12 +1,12 @@
 package net.trilogy.arch.adapter.graphviz;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-
 import guru.nidi.graphviz.engine.Format;
 import guru.nidi.graphviz.engine.Graphviz;
 import guru.nidi.graphviz.parse.Parser;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 
 public class GraphvizInterface {
     public void render(String dotGraph, Path outputPath) throws IOException {

--- a/src/main/java/net/trilogy/arch/adapter/jira/JiraQueryResult.java
+++ b/src/main/java/net/trilogy/arch/adapter/jira/JiraQueryResult.java
@@ -1,12 +1,11 @@
 package net.trilogy.arch.adapter.jira;
 
-import java.net.http.HttpResponse;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import lombok.Getter;
+
+import java.net.http.HttpResponse;
 
 @Getter
 public class JiraQueryResult {

--- a/src/main/java/net/trilogy/arch/adapter/structurizr/Credentials.java
+++ b/src/main/java/net/trilogy/arch/adapter/structurizr/Credentials.java
@@ -24,7 +24,6 @@ public abstract class Credentials {
     private static final String API_KEY_ENV_VAR_NAME = "STRUCTURIZR_API_KEY";
     private static final String API_SECRET_ENV_VAR_NAME = "STRUCTURIZR_API_SECRET";
 
-
     public static WorkspaceConfig config() {
         checkArgument(workspaceId().isPresent(), "Workspace id missing. Check config.");
         checkArgument(apiKey().isPresent(), "Structurizr api key missing. Check config.");

--- a/src/main/java/net/trilogy/arch/commands/ImportCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/ImportCommand.java
@@ -19,17 +19,14 @@ import java.util.concurrent.Callable;
 
 @Command(name = "import", mixinStandardHelpOptions = true, description = "Imports existing structurizr workspace, overwriting the existing product architecture.")
 public class ImportCommand implements Callable<Integer>, DisplaysOutputMixin, DisplaysErrorMixin {
+    private final FilesFacade filesFacade;
     @Parameters(index = "0", paramLabel = "EXPORTED_WORKSPACE", description = "Exported structurizr workspace json file location.")
     private File exportedWorkspacePath;
-
     @Parameters(index = "1", description = "Product architecture root directory")
     private File productArchitectureDirectory;
-
     @Getter
     @Spec
     private CommandLine.Model.CommandSpec spec;
-
-    private final FilesFacade filesFacade;
 
     public ImportCommand(FilesFacade filesFacade) {
         this.filesFacade = filesFacade;

--- a/src/main/java/net/trilogy/arch/commands/InitializeCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/InitializeCommand.java
@@ -20,23 +20,18 @@ import static net.trilogy.arch.adapter.structurizr.Credentials.createCredentials
 
 @Command(name = "init", description = "Initializes a new workspace directory to contain a single project architecture, AUs, documentation, and credentials for Structurizr imports and exports. This is generally the first command to be run.", mixinStandardHelpOptions = true)
 public class InitializeCommand implements Callable<Integer>, DisplaysOutputMixin, DisplaysErrorMixin {
+    private final FilesFacade filesFacade;
     @Option(names = {"-i", "--workspace-id"}, description = "Structurizr workspace id", required = true)
     private String workspaceId;
-
     @Option(names = {"-k", "--workspace-api-key"}, description = "Structurizr workspace api key", required = true)
     private String apiKey;
-
     @Option(names = {"-s", "--workspace-api-secret"}, description = "Structurizr workspace api secret", required = true)
     private String apiSecret;
-
     @Parameters(index = "0", description = "Directory to initialize")
     private File productArchitectureDirectory;
-
     @Getter
     @Spec
     private CommandLine.Model.CommandSpec spec;
-
-    private final FilesFacade filesFacade;
 
     public InitializeCommand(FilesFacade filesFacade) {
         this.filesFacade = filesFacade;

--- a/src/main/java/net/trilogy/arch/commands/ListComponentsCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/ListComponentsCommand.java
@@ -22,22 +22,18 @@ import static java.util.Comparator.comparing;
 
 @CommandLine.Command(name = "list-components", mixinStandardHelpOptions = true, description = "Outputs a CSV formatted list of components and their IDs, which are present in the architecture.")
 public class ListComponentsCommand implements Callable<Integer>, LoadArchitectureMixin, DisplaysOutputMixin {
+    @Getter
+    private final ArchitectureDataStructureObjectMapper architectureDataStructureObjectMapper;
+    @Getter
+    private final FilesFacade filesFacade;
     @Option(names = {"-s", "--search"}, description = "Search string to be part of name or description to find matching components.")
     private String searchString;
-
     @Getter
     @Spec
     private CommandSpec spec;
-
     @Getter
     @Parameters(index = "0", description = "Directory containing the product architecture")
     private File productArchitectureDirectory;
-
-    @Getter
-    private final ArchitectureDataStructureObjectMapper architectureDataStructureObjectMapper;
-
-    @Getter
-    private final FilesFacade filesFacade;
 
     public ListComponentsCommand(FilesFacade filesFacade) {
         this.filesFacade = filesFacade;

--- a/src/main/java/net/trilogy/arch/commands/ParentCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/ParentCommand.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
 @Command(

--- a/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuAnnotateCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuAnnotateCommand.java
@@ -21,23 +21,19 @@ import java.util.concurrent.Callable;
 
 @Command(name = "annotate", description = "Annotates the architecture update with comments detailing the full paths of all components referenced by ID. Makes the AU easier to read.", mixinStandardHelpOptions = true)
 public class AuAnnotateCommand implements Callable<Integer>, LoadArchitectureMixin, DisplaysOutputMixin, DisplaysErrorMixin {
-    @Parameters(index = "0", description = "Directory name of architecture update to annotate")
-    private File architectureUpdateDirectory;
-
-    @Getter
-    @Parameters(index = "1", description = "Product architecture root directory")
-    private File productArchitectureDirectory;
-
-    @Getter
-    @Spec
-    private CommandSpec spec;
-
     @Getter
     private final FilesFacade filesFacade;
-
     @Getter
     private final ArchitectureDataStructureObjectMapper architectureDataStructureObjectMapper;
     private final ArchitectureUpdateReader architectureUpdateReader;
+    @Parameters(index = "0", description = "Directory name of architecture update to annotate")
+    private File architectureUpdateDirectory;
+    @Getter
+    @Parameters(index = "1", description = "Product architecture root directory")
+    private File productArchitectureDirectory;
+    @Getter
+    @Spec
+    private CommandSpec spec;
 
     public AuAnnotateCommand(FilesFacade filesFacade) {
         this.filesFacade = filesFacade;

--- a/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuCommand.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Callable;
         name = "architecture-update",
         aliases = "au",
         description = "Namespace for Architecture Update commands.",
-        mixinStandardHelpOptions=true
+        mixinStandardHelpOptions = true
 )
 public class AuCommand implements Callable<Integer>, DisplaysOutputMixin {
     public static final String ARCHITECTURE_UPDATES_ROOT_FOLDER = "architecture-updates";

--- a/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuPublishStoriesCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuPublishStoriesCommand.java
@@ -37,17 +37,13 @@ public class AuPublishStoriesCommand implements Callable<Integer>, LoadArchitect
     private final FilesFacade filesFacade;
     @Getter
     private final GitInterface gitInterface;
-
+    @Option(names = {"-b", "--branch-of-base-architecture"}, description = "Name of git branch from which this AU was branched. Used to get names of components. Usually 'master'. Also can be a commit or tag.", required = true)
+    String baseBranch;
     @Parameters(index = "0", description = "Directory name of architecture update to validate")
     private File architectureUpdateDirectory;
-
     @Getter
     @Parameters(index = "1", description = "Product architecture root directory")
     private File productArchitectureDirectory;
-
-    @Option(names = {"-b", "--branch-of-base-architecture"}, description = "Name of git branch from which this AU was branched. Used to get names of components. Usually 'master'. Also can be a commit or tag.", required = true)
-    String baseBranch;
-
     @Option(names = {"-u", "--username"}, description = "Jira username", required = true)
     private String username;
 

--- a/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuValidateCommand.java
+++ b/src/main/java/net/trilogy/arch/commands/architectureUpdate/AuValidateCommand.java
@@ -37,33 +37,26 @@ import static picocli.CommandLine.Spec;
 @Command(name = "validate", description = "Validate Architecture Update", mixinStandardHelpOptions = true)
 public class AuValidateCommand implements Callable<Integer>, LoadArchitectureFromGitMixin, LoadArchitectureMixin, DisplaysErrorMixin, DisplaysOutputMixin {
     @Getter
-    @Spec
-    private CommandSpec spec;
-
-    @Parameters(index = "0", description = "Directory name of architecture update to validate")
-    private File architectureUpdateDirectory;
-
-    @Getter
-    @Parameters(index = "1", description = "Product architecture root directory")
-    private File productArchitectureDirectory;
-
-    @Getter
     private final ArchitectureDataStructureObjectMapper architectureDataStructureObjectMapper;
     @Getter
     private final FilesFacade filesFacade;
     @Getter
     private final GitInterface gitInterface;
-
+    private final ArchitectureUpdateReader architectureUpdateReader;
     @Option(names = {"-b", "--branch-of-base-architecture"}, description = "Name of git branch from which this AU was branched. Used to validate changes. Usually 'master'. Also can be a commit or tag.", required = true)
     String baseBranch;
-
     @Option(names = {"-t", "--TDDs"}, description = "Run validation for TDDs only")
     boolean tddValidation;
-
     @Option(names = {"-s", "--stories"}, description = "Run validation for feature stories only")
     boolean capabilityValidation;
-
-    private final ArchitectureUpdateReader architectureUpdateReader;
+    @Getter
+    @Spec
+    private CommandSpec spec;
+    @Parameters(index = "0", description = "Directory name of architecture update to validate")
+    private File architectureUpdateDirectory;
+    @Getter
+    @Parameters(index = "1", description = "Product architecture root directory")
+    private File productArchitectureDirectory;
 
     public AuValidateCommand(FilesFacade filesFacade, GitInterface gitInterface) {
         this.filesFacade = filesFacade;

--- a/src/main/java/net/trilogy/arch/commands/mixin/DisplaysErrorMixin.java
+++ b/src/main/java/net/trilogy/arch/commands/mixin/DisplaysErrorMixin.java
@@ -14,7 +14,7 @@ public interface DisplaysErrorMixin {
     default void printError(String errorMessage, Exception exception) {
         printError(errorMessage);
         printError("Error: " + exception);
-        if(exception.getCause() != null) {
+        if (exception.getCause() != null) {
             printError("Cause: " + exception.getCause());
         }
 

--- a/src/main/java/net/trilogy/arch/commands/mixin/DisplaysOutputMixin.java
+++ b/src/main/java/net/trilogy/arch/commands/mixin/DisplaysOutputMixin.java
@@ -16,7 +16,7 @@ public interface DisplaysOutputMixin {
 
     default void logArgs() {
         LogManager.getLogger(getClass()).info(getClass().getSimpleName() + " with args : " + getSpec().args().stream().map(this::maskedParamValue
-        ).collect( Collectors.joining( " ") ));
+        ).collect(Collectors.joining(" ")));
     }
 
     default String maskedParamValue(CommandLine.Model.ArgSpec spec) {

--- a/src/main/java/net/trilogy/arch/config/AppConfig.java
+++ b/src/main/java/net/trilogy/arch/config/AppConfig.java
@@ -1,18 +1,18 @@
 package net.trilogy.arch.config;
 
-import lombok.Getter;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.io.File;
 import java.util.Optional;
 
 @Builder
 public class AppConfig {
-  @Getter
-  @Builder.Default
-  private final String logPath = envOrDefault("LOG_PATH", System.getProperty("user.home") + File.separator + ".arch-as-code" + File.separator + "arch-as-code.log");
+    @Getter
+    @Builder.Default
+    private final String logPath = envOrDefault("LOG_PATH", System.getProperty("user.home") + File.separator + ".arch-as-code" + File.separator + "arch-as-code.log");
 
-  private static String envOrDefault(String envName, String orElse) {
-    return Optional.ofNullable(System.getenv(envName)).orElse(orElse);
-  }
+    private static String envOrDefault(String envName, String orElse) {
+        return Optional.ofNullable(System.getenv(envName)).orElse(orElse);
+    }
 }

--- a/src/main/java/net/trilogy/arch/domain/DocumentationSection.java
+++ b/src/main/java/net/trilogy/arch/domain/DocumentationSection.java
@@ -18,11 +18,6 @@ public class DocumentationSection {
     private final Format format;
     private final String content;
 
-    public enum Format {
-        MARKDOWN,
-        ASCIIDOC
-    }
-
     public static DocumentationSection createFromFile(File file, FilesFacade filesFacade) throws IOException {
         if (file == null || file.isDirectory()) return null;
 
@@ -36,13 +31,6 @@ public class DocumentationSection {
         return new DocumentationSection(null, title, order, format, content);
     }
 
-    public String getFileName() {
-        if (getOrder() == null) return title + extensionFromFormat(getFormat());
-
-        return getOrder().toString() + "_" + title + extensionFromFormat(getFormat());
-    }
-
-
     private static String getTitleFromFullname(String fullName, Integer order) {
         final String nameWithoutExtension = Files.getNameWithoutExtension(fullName);
 
@@ -55,23 +43,10 @@ public class DocumentationSection {
         return s[1];
     }
 
-    public com.structurizr.documentation.Format getStructurizrFormat() {
-        if (getFormat().equals(Format.MARKDOWN)) return Markdown;
-
-        return AsciiDoc;
-    }
-
     private static Format formatFromExtension(String extension) {
         if (extension.equals("md")) return Format.MARKDOWN;
 
         return Format.ASCIIDOC;
-    }
-
-    private String extensionFromFormat(Format format) {
-        if (format == null) return "";
-        if (format.equals(Format.MARKDOWN)) return ".md";
-
-        return ".txt";
     }
 
     private static Integer getOrderFromFullname(String name) {
@@ -86,5 +61,30 @@ public class DocumentationSection {
         }
 
         return order;
+    }
+
+    public String getFileName() {
+        if (getOrder() == null)
+            return title + extensionFromFormat(getFormat());
+
+        return getOrder().toString() + "_" + title + extensionFromFormat(getFormat());
+    }
+
+    public com.structurizr.documentation.Format getStructurizrFormat() {
+        if (getFormat().equals(Format.MARKDOWN)) return Markdown;
+
+        return AsciiDoc;
+    }
+
+    private String extensionFromFormat(Format format) {
+        if (format == null) return "";
+        if (format.equals(Format.MARKDOWN)) return ".md";
+
+        return ".txt";
+    }
+
+    public enum Format {
+        MARKDOWN,
+        ASCIIDOC
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/ArchitectureUpdate.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/ArchitectureUpdate.java
@@ -31,21 +31,34 @@ import java.util.stream.Collectors;
         "capabilities"
 })
 public class ArchitectureUpdate {
-    @JsonProperty(value = "name") private final String name;
-    @JsonProperty(value = "milestone") private final String milestone;
-    @JsonProperty(value = "authors") private final List<Person> authors;
-    @JsonProperty(value = "PCAs") private final List<Person> PCAs;
-    @JsonProperty(value = "P2") private final P2 p2;
-    @JsonProperty(value = "P1") private final P1 p1;
-    @JsonProperty(value = "useful-links") private final List<Link> usefulLinks;
-    @JsonProperty(value = "milestone-dependencies") private final List<MilestoneDependency> milestoneDependencies;
-    @JsonProperty(value = "decisions") private final Map<Decision.Id, Decision> decisions;
-    @JsonProperty(value = "tdds-per-component") private final List<TddContainerByComponent> tddContainersByComponent;
-    @JsonProperty(value = "functional-requirements") private final Map<FunctionalRequirement.Id, FunctionalRequirement> functionalRequirements;
-    @JsonProperty(value = "capabilities") private final CapabilitiesContainer capabilityContainer;
+    @JsonProperty(value = "name")
+    private final String name;
+    @JsonProperty(value = "milestone")
+    private final String milestone;
+    @JsonProperty(value = "authors")
+    private final List<Person> authors;
+    @JsonProperty(value = "PCAs")
+    private final List<Person> PCAs;
+    @JsonProperty(value = "P2")
+    private final P2 p2;
+    @JsonProperty(value = "P1")
+    private final P1 p1;
+    @JsonProperty(value = "useful-links")
+    private final List<Link> usefulLinks;
+    @JsonProperty(value = "milestone-dependencies")
+    private final List<MilestoneDependency> milestoneDependencies;
+    @JsonProperty(value = "decisions")
+    private final Map<Decision.Id, Decision> decisions;
+    @JsonProperty(value = "tdds-per-component")
+    private final List<TddContainerByComponent> tddContainersByComponent;
+    @JsonProperty(value = "functional-requirements")
+    private final Map<FunctionalRequirement.Id, FunctionalRequirement> functionalRequirements;
+    @JsonProperty(value = "capabilities")
+    private final CapabilitiesContainer capabilityContainer;
 
     //TODO remove tddContents per https://tw-trilogy.atlassian.net/browse/AAC-160
-    @JsonIgnore private final List<TddContent> tddContents;
+    @JsonIgnore
+    private final List<TddContent> tddContents;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/CapabilitiesContainer.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/CapabilitiesContainer.java
@@ -2,7 +2,6 @@ package net.trilogy.arch.domain.architectureUpdate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -14,8 +13,10 @@ import java.util.List;
 @ToString
 @EqualsAndHashCode
 public class CapabilitiesContainer {
-    @JsonProperty(value = "epic") private final Epic epic;
-    @JsonProperty(value = "feature-stories") private final List<FeatureStory> featureStories;
+    @JsonProperty(value = "epic")
+    private final Epic epic;
+    @JsonProperty(value = "feature-stories")
+    private final List<FeatureStory> featureStories;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/EntityReference.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/EntityReference.java
@@ -3,5 +3,4 @@ package net.trilogy.arch.domain.architectureUpdate;
 public interface EntityReference {
 
     String toString();
-
 }

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/Epic.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/Epic.java
@@ -13,9 +13,10 @@ public class Epic {
     public static final String BLANK_AU_EPIC_JIRA_LINK_VALUE = "Please enter epic link from Jira";
     public static final String BLANK_AU_EPIC_JIRA_TICKET_VALUE = "please-enter-epic-ticket-from-jira";
 
-
-    @JsonProperty(value = "title") private final String title;
-    @JsonProperty(value = "jira") private final Jira jira;
+    @JsonProperty(value = "title")
+    private final String title;
+    @JsonProperty(value = "jira")
+    private final Jira jira;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/FeatureStory.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/FeatureStory.java
@@ -2,7 +2,6 @@ package net.trilogy.arch.domain.architectureUpdate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -14,10 +13,14 @@ import java.util.List;
 @Getter
 @EqualsAndHashCode
 public class FeatureStory {
-    @JsonProperty(value = "title") private final String title;
-    @JsonProperty(value = "jira") private final Jira jira;
-    @JsonProperty(value = "tdd-references") private final List<Tdd.Id> tddReferences;
-    @JsonProperty(value = "functional-requirement-references") private final List<FunctionalRequirement.Id> requirementReferences;
+    @JsonProperty(value = "title")
+    private final String title;
+    @JsonProperty(value = "jira")
+    private final Jira jira;
+    @JsonProperty(value = "tdd-references")
+    private final List<Tdd.Id> tddReferences;
+    @JsonProperty(value = "functional-requirement-references")
+    private final List<FunctionalRequirement.Id> requirementReferences;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/Jira.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/Jira.java
@@ -11,8 +11,10 @@ import lombok.ToString;
 @Getter
 @EqualsAndHashCode
 public class Jira {
-    @JsonProperty(value = "ticket") private final String ticket;
-    @JsonProperty(value = "link") private final String link;
+    @JsonProperty(value = "ticket")
+    private final String ticket;
+    @JsonProperty(value = "link")
+    private final String link;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/Link.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/Link.java
@@ -8,8 +8,10 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode
 public class Link {
-    @JsonProperty(value = "description") private final String description;
-    @JsonProperty(value = "link") private final String link;
+    @JsonProperty(value = "description")
+    private final String description;
+    @JsonProperty(value = "link")
+    private final String link;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public Link(

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/MilestoneDependency.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/MilestoneDependency.java
@@ -11,8 +11,10 @@ import java.util.List;
 @Getter
 @EqualsAndHashCode
 public class MilestoneDependency {
-    @JsonProperty(value = "description") private final String description;
-    @JsonProperty(value = "links") private final List<Link> links;
+    @JsonProperty(value = "description")
+    private final String description;
+    @JsonProperty(value = "links")
+    private final List<Link> links;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/P1.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/P1.java
@@ -9,9 +9,12 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode
 public class P1 {
-    @JsonProperty(value = "link") private final String link;
-    @JsonProperty(value = "jira") private final Jira jira;
-    @JsonProperty(value = "executive-summary") private final String executiveSummary;
+    @JsonProperty(value = "link")
+    private final String link;
+    @JsonProperty(value = "jira")
+    private final Jira jira;
+    @JsonProperty(value = "executive-summary")
+    private final String executiveSummary;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/P2.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/P2.java
@@ -9,8 +9,10 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode
 public class P2 {
-    @JsonProperty(value = "link") private final String link;
-    @JsonProperty(value = "jira") private final Jira jira;
+    @JsonProperty(value = "link")
+    private final String link;
+    @JsonProperty(value = "jira")
+    private final Jira jira;
 
     @Builder(toBuilder = true)
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/Person.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/Person.java
@@ -6,8 +6,10 @@ import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode
 public class Person {
-    @JsonProperty(value = "name") private final String name;
-    @JsonProperty(value = "email") private final String email;
+    @JsonProperty(value = "name")
+    private final String name;
+    @JsonProperty(value = "email")
+    private final String email;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public Person(

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/Tdd.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/Tdd.java
@@ -33,15 +33,15 @@ public class Tdd {
         this.file = file;
     }
 
+    public static Tdd blank() {
+        return new Tdd("[SAMPLE TDD TEXT LONG TEXT FORMAT]\nLine 2\nLine 3", null);
+    }
+
     public String getDetails() {
         if (content.isPresent()) {
             return content.get().getContent();
         }
         return text;
-    }
-
-    public static Tdd blank() {
-        return new Tdd("[SAMPLE TDD TEXT LONG TEXT FORMAT]\nLine 2\nLine 3", null);
     }
 
     @EqualsAndHashCode

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/TddContainerByComponent.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/TddContainerByComponent.java
@@ -41,11 +41,11 @@ public class TddContainerByComponent {
         this.tdds = tdds;
     }
 
-    public boolean isDeleted() {
-        return deleted != null && deleted;
-    }
-
     public static TddContainerByComponent blank() {
         return new TddContainerByComponent(Tdd.ComponentReference.blank(), null, false, Map.of(Tdd.Id.blank(), Tdd.blank()));
+    }
+
+    public boolean isDeleted() {
+        return deleted != null && deleted;
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/architectureUpdate/TddContent.java
+++ b/src/main/java/net/trilogy/arch/domain/architectureUpdate/TddContent.java
@@ -17,15 +17,12 @@ import java.util.regex.Pattern;
 public class TddContent {
     public static final int TDD_MATCHER_GROUP = 1;
     public static final int COMPONENT_ID_MATCHER_GROUP = 2;
-
-    private final String content;
-    private final String filename;
-
     private static final String REGEX = "(.*) : Component-([a-zA-Z\\d]+)";
     private static final Pattern pattern = Pattern.compile(REGEX);
+    private final String content;
+    private final String filename;
     @EqualsAndHashCode.Exclude
     private Matcher matcher;
-
 
     public TddContent(String content, String filename) {
         this.content = content;

--- a/src/main/java/net/trilogy/arch/domain/c4/C4Component.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/C4Component.java
@@ -58,6 +58,11 @@ public class C4Component extends Entity implements HasTechnology, HasUrl {
         return C4Type.COMPONENT;
     }
 
+    @Override
+    public C4Component shallowCopy() {
+        return this.toBuilder().build();
+    }
+
     public static class C4ComponentBuilder {
         public C4ComponentBuilder path(C4Path path) {
             if (path == null) return this;
@@ -65,10 +70,5 @@ public class C4Component extends Entity implements HasTechnology, HasUrl {
             this.path = path;
             return this;
         }
-    }
-
-    @Override
-    public C4Component shallowCopy() {
-        return this.toBuilder().build();
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/c4/C4Container.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/C4Container.java
@@ -53,6 +53,11 @@ public class C4Container extends Entity implements HasTechnology, HasUrl {
         return C4Type.CONTAINER;
     }
 
+    @Override
+    public C4Container shallowCopy() {
+        return this.toBuilder().build();
+    }
+
     public static class C4ContainerBuilder {
         public C4ContainerBuilder path(C4Path path) {
             if (path == null) return this;
@@ -60,10 +65,5 @@ public class C4Container extends Entity implements HasTechnology, HasUrl {
             this.path = path;
             return this;
         }
-    }
-
-    @Override
-    public C4Container shallowCopy() {
-        return this.toBuilder().build();
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/c4/C4Path.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/C4Path.java
@@ -60,15 +60,6 @@ public class C4Path {
         return new C4Path(path);
     }
 
-    private Matcher matcher() {
-        if (this.matcher == null) {
-            this.matcher = pattern.matcher(this.path);
-            boolean found = matcher.find();
-            checkArgument(found, String.format("Path does not match expected pattern. (%s)", this.path));
-        }
-        return this.matcher;
-    }
-
     public static C4Path buildPath(Element element) {
         if (element.getParent() == null) {
             String prefix = "c4://";
@@ -83,6 +74,15 @@ public class C4Path {
         @NonNull String c4Path = buildPath(element.getParent()).getPath();
         String fullPath = c4Path + "/" + element.getName().replaceAll("/", "\\\\/");
         return new C4Path(fullPath);
+    }
+
+    private Matcher matcher() {
+        if (this.matcher == null) {
+            this.matcher = pattern.matcher(this.path);
+            boolean found = matcher.find();
+            checkArgument(found, String.format("Path does not match expected pattern. (%s)", this.path));
+        }
+        return this.matcher;
     }
 
     public String name() {

--- a/src/main/java/net/trilogy/arch/domain/c4/C4Person.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/C4Person.java
@@ -17,10 +17,6 @@ import static java.lang.String.format;
 public class C4Person extends Entity implements HasLocation {
     private C4Location location;
 
-    public C4Type getType() {
-        return C4Type.PERSON;
-    }
-
     @Builder(toBuilder = true)
     C4Person(String id,
              String alias,
@@ -34,6 +30,15 @@ public class C4Person extends Entity implements HasLocation {
         this.location = location;
     }
 
+    public C4Type getType() {
+        return C4Type.PERSON;
+    }
+
+    @Override
+    public C4Person shallowCopy() {
+        return this.toBuilder().build();
+    }
+
     public static class C4PersonBuilder {
         public C4PersonBuilder path(C4Path path) {
             if (path == null) return this;
@@ -41,10 +46,5 @@ public class C4Person extends Entity implements HasLocation {
             this.path = path;
             return this;
         }
-    }
-
-    @Override
-    public C4Person shallowCopy() {
-        return this.toBuilder().build();
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/c4/C4Relationship.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/C4Relationship.java
@@ -18,12 +18,6 @@ public class C4Relationship implements Comparable<C4Relationship> {
     private String withId;
     @NonNull
     private String description;
-
-    @Override
-    public int compareTo(C4Relationship other) {
-        return this.getId().compareTo(other.getId());
-    }
-
     private String technology;
 
     @Builder(toBuilder = true)
@@ -35,5 +29,10 @@ public class C4Relationship implements Comparable<C4Relationship> {
         this.withId = withId;
         this.description = description;
         this.technology = technology;
+    }
+
+    @Override
+    public int compareTo(C4Relationship other) {
+        return this.getId().compareTo(other.getId());
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/c4/C4SoftwareSystem.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/C4SoftwareSystem.java
@@ -38,6 +38,11 @@ public class C4SoftwareSystem extends Entity implements HasLocation {
         return C4Type.SYSTEM;
     }
 
+    @Override
+    public C4SoftwareSystem shallowCopy() {
+        return this.toBuilder().build();
+    }
+
     public static class C4SoftwareSystemBuilder {
         public C4SoftwareSystemBuilder path(C4Path path) {
             if (path == null) return this;
@@ -45,10 +50,5 @@ public class C4SoftwareSystem extends Entity implements HasLocation {
             this.path = path;
             return this;
         }
-    }
-
-    @Override
-    public C4SoftwareSystem shallowCopy() {
-        return this.toBuilder().build();
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/c4/Entity.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/Entity.java
@@ -26,15 +26,6 @@ public abstract class Entity implements HasRelation, HasTag, HasIdentity, Compar
     protected Set<C4Tag> tags = emptySet();
     protected Set<C4Relationship> relationships = emptySet();
 
-    abstract public Entity shallowCopy();
-
-    abstract public C4Type getType();
-
-    @Override
-    public int compareTo(Entity other) {
-        return this.getId().compareTo(other.getId());
-    }
-
     public Entity(@NonNull String id, String alias, C4Path path, @NonNull String name, String description, Set<C4Tag> tags, Set<C4Relationship> relationships) {
         this.id = id;
         this.alias = alias;
@@ -43,6 +34,15 @@ public abstract class Entity implements HasRelation, HasTag, HasIdentity, Compar
         this.tags = ofNullable(tags).orElse(emptySet());
         this.relationships = ofNullable(relationships).orElse(emptySet());
         this.name = name;
+    }
+
+    abstract public Entity shallowCopy();
+
+    abstract public C4Type getType();
+
+    @Override
+    public int compareTo(Entity other) {
+        return this.getId().compareTo(other.getId());
     }
 
     public void setPath(String path) {

--- a/src/main/java/net/trilogy/arch/domain/c4/HasIdentity.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/HasIdentity.java
@@ -2,5 +2,6 @@ package net.trilogy.arch.domain.c4;
 
 public interface HasIdentity {
     String getId();
+
     String getAlias();
 }

--- a/src/main/java/net/trilogy/arch/domain/c4/view/ModelMediator.java
+++ b/src/main/java/net/trilogy/arch/domain/c4/view/ModelMediator.java
@@ -26,6 +26,7 @@ import static net.trilogy.arch.transformation.DeploymentNodeTransformer.addDeplo
 import static net.trilogy.arch.transformation.LocationTransformer.c4LocationToLocation;
 
 public class ModelMediator {
+    private static final ObjectMapper jackson = new ObjectMapper();
     private final Model model;
     private final FunctionalIdGenerator idGenerator;
 
@@ -37,6 +38,16 @@ public class ModelMediator {
     public ModelMediator(Model model) {
         this.model = model;
         this.idGenerator = new FunctionalIdGenerator();
+    }
+
+    private static String str(List<String> lst) {
+        try {
+            return jackson.writeValueAsString(lst);
+        } catch (final JsonProcessingException e) {
+            final var x = new IllegalStateException("BUG: Impossible exception: " + e, e);
+            x.setStackTrace(e.getStackTrace());
+            throw x;
+        }
     }
 
     public Person person(String id) {
@@ -113,18 +124,6 @@ public class ModelMediator {
 
     public DeploymentNode addDeploymentNode(C4Model dataStructureModel, C4DeploymentNode c4DeploymentNode) {
         return addDeploymentNodeFromC4ToModel(c4DeploymentNode, dataStructureModel, model, idGenerator);
-    }
-
-    private static final ObjectMapper jackson = new ObjectMapper();
-
-    private static String str(List<String> lst) {
-        try {
-            return jackson.writeValueAsString(lst);
-        } catch (final JsonProcessingException e) {
-            final var x = new IllegalStateException("BUG: Impossible exception: " + e, e);
-            x.setStackTrace(e.getStackTrace());
-            throw x;
-        }
     }
 
     private String[] getTags(HasTag t) {

--- a/src/main/java/net/trilogy/arch/domain/diff/Diff.java
+++ b/src/main/java/net/trilogy/arch/domain/diff/Diff.java
@@ -11,7 +11,8 @@ public class Diff {
     final private Diffable after;
     final private Set<? extends Diffable> descendantsBefore;
     final private Set<? extends Diffable> descendantsAfter;
-    @Getter final private Status status;
+    @Getter
+    final private Status status;
 
     public Diff(Diffable before, Diffable after) {
         this.before = before;
@@ -21,10 +22,19 @@ public class Diff {
         this.status = calculateStatus();
     }
 
+    public Diff(Diffable before, Set<? extends Diffable> descendantsBefore, Diffable after, Set<? extends Diffable> descendantsAfter) {
+        this.before = before;
+        this.after = after;
+        this.descendantsBefore = descendantsBefore;
+        this.descendantsAfter = descendantsAfter;
+        this.status = calculateStatus();
+    }
+
     public String toString() {
         String marker;
         if (status.equals(Status.UPDATED)) marker = "*";
-        else if (status.equals(Status.NO_UPDATE_BUT_CHILDREN_UPDATED)) marker = "~";
+        else if (status.equals(Status.NO_UPDATE_BUT_CHILDREN_UPDATED))
+            marker = "~";
         else if (status.equals(Status.CREATED)) marker = "+";
         else if (status.equals(Status.DELETED)) marker = "-";
         else marker = "=";
@@ -39,31 +49,17 @@ public class Diff {
         return marker + id;
     }
 
-    public Diff(Diffable before, Set<? extends Diffable> descendantsBefore, Diffable after, Set<? extends Diffable> descendantsAfter) {
-        this.before = before;
-        this.after = after;
-        this.descendantsBefore = descendantsBefore;
-        this.descendantsAfter = descendantsAfter;
-        this.status = calculateStatus();
-    }
-
     private Status calculateStatus() {
-        if (before == null && after == null) throw new IllegalArgumentException(
-                "Can't create Diff if states 'before' and 'after' are both null."
-        );
+        if (before == null && after == null)
+            throw new IllegalArgumentException(
+                    "Can't create Diff if states 'before' and 'after' are both null."
+            );
         if (before == null) return Status.CREATED;
         if (after == null) return Status.DELETED;
         if (!before.equals(after)) return Status.UPDATED;
-        if (!descendantsBefore.equals(descendantsAfter)) return Status.NO_UPDATE_BUT_CHILDREN_UPDATED;
+        if (!descendantsBefore.equals(descendantsAfter))
+            return Status.NO_UPDATE_BUT_CHILDREN_UPDATED;
         return Status.NO_UPDATE;
-    }
-
-    public enum Status {
-        CREATED,
-        UPDATED,
-        DELETED,
-        NO_UPDATE_BUT_CHILDREN_UPDATED,
-        NO_UPDATE
     }
 
     public Diffable getElement() {
@@ -72,5 +68,13 @@ public class Diff {
 
     public Set<? extends Diffable> getDescendants() {
         return after != null ? descendantsAfter : descendantsBefore;
+    }
+
+    public enum Status {
+        CREATED,
+        UPDATED,
+        DELETED,
+        NO_UPDATE_BUT_CHILDREN_UPDATED,
+        NO_UPDATE
     }
 }

--- a/src/main/java/net/trilogy/arch/domain/diff/Diffable.java
+++ b/src/main/java/net/trilogy/arch/domain/diff/Diffable.java
@@ -7,10 +7,16 @@ import java.util.Map;
 
 public interface Diffable {
     C4Type getType();
+
     String getId();
+
     String getName();
+
     String[] getRelatedTddsText();
+
     void setRelatedTdds(Map<Tdd.Id, Tdd> relatedTo);
+
     boolean hasRelatedTdds();
+
     boolean equals(Object o);
 }

--- a/src/main/java/net/trilogy/arch/domain/diff/DiffableEntity.java
+++ b/src/main/java/net/trilogy/arch/domain/diff/DiffableEntity.java
@@ -30,7 +30,8 @@ public class DiffableEntity extends DiffableWithRelatedTdds implements Diffable 
         final var other = (DiffableEntity) otherObject;
 
         if (Objects.equals(entity, other.entity)) return true;
-        if (Objects.isNull(entity) != Objects.isNull(other.entity)) return false;
+        if (Objects.isNull(entity) != Objects.isNull(other.entity))
+            return false;
 
         var a = entity.shallowCopy();
         var b = other.entity.shallowCopy();

--- a/src/main/java/net/trilogy/arch/domain/diff/DiffableWithRelatedTdds.java
+++ b/src/main/java/net/trilogy/arch/domain/diff/DiffableWithRelatedTdds.java
@@ -18,6 +18,6 @@ public abstract class DiffableWithRelatedTdds {
     }
 
     public boolean hasRelatedTdds() {
-        return relatedTdds != null && ! relatedTdds.isEmpty();
+        return relatedTdds != null && !relatedTdds.isEmpty();
     }
 }

--- a/src/main/java/net/trilogy/arch/publish/ArchitectureDataStructurePublisher.java
+++ b/src/main/java/net/trilogy/arch/publish/ArchitectureDataStructurePublisher.java
@@ -59,5 +59,4 @@ public class ArchitectureDataStructurePublisher {
 
         return new ArchitectureDataStructureObjectMapper().readValue(archAsString);
     }
-
 }

--- a/src/main/java/net/trilogy/arch/services/Base64Converter.java
+++ b/src/main/java/net/trilogy/arch/services/Base64Converter.java
@@ -23,7 +23,6 @@ public class Base64Converter {
         return Base64.getEncoder().encodeToString(bytes);
     }
 
-
     public static Boolean toFile(FilesFacade filesFacade, String encodedString, Path outputStreamPath) throws IOException {
         final byte[] decoded = Base64.getDecoder().decode(encodedString);
         final FileOutputStream outputStream = filesFacade.newFileOutputStream(outputStreamPath.toString());

--- a/src/main/java/net/trilogy/arch/services/DiffToDotCalculator.java
+++ b/src/main/java/net/trilogy/arch/services/DiffToDotCalculator.java
@@ -63,18 +63,6 @@ public class DiffToDotCalculator {
         return dot.toString();
     }
 
-    private static class Dot {
-        private final StringBuilder builder = new StringBuilder();
-
-        public String toString() {
-            return builder.toString();
-        }
-
-        public void add(int indentationLevel, String line) {
-            builder.append("    ".repeat(indentationLevel)).append(line).append("\n");
-        }
-    }
-
     @VisibleForTesting
     static String getDotLabel(DiffableEntity entity) {
         return "<<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\"><TR><TD>" + entity.getName() + "</TD></TR>" +
@@ -172,5 +160,17 @@ public class DiffToDotCalculator {
                 .map(it -> it.getElement().getName())
                 .orElse(rel.getDestinationId());
         return source + " -> " + destination;
+    }
+
+    private static class Dot {
+        private final StringBuilder builder = new StringBuilder();
+
+        public String toString() {
+            return builder.toString();
+        }
+
+        public void add(int indentationLevel, String line) {
+            builder.append("    ".repeat(indentationLevel)).append(line).append("\n");
+        }
     }
 }

--- a/src/main/java/net/trilogy/arch/transformation/enhancer/DecisionEnhancer.java
+++ b/src/main/java/net/trilogy/arch/transformation/enhancer/DecisionEnhancer.java
@@ -4,8 +4,11 @@ import com.structurizr.Workspace;
 import com.structurizr.documentation.DecisionStatus;
 import net.trilogy.arch.domain.ArchitectureDataStructure;
 
+import static com.structurizr.documentation.DecisionStatus.Accepted;
 import static com.structurizr.documentation.DecisionStatus.Deprecated;
-import static com.structurizr.documentation.DecisionStatus.*;
+import static com.structurizr.documentation.DecisionStatus.Proposed;
+import static com.structurizr.documentation.DecisionStatus.Rejected;
+import static com.structurizr.documentation.DecisionStatus.Superseded;
 import static com.structurizr.documentation.Format.Markdown;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;

--- a/src/main/java/net/trilogy/arch/validation/ArchitectureDataStructureValidator.java
+++ b/src/main/java/net/trilogy/arch/validation/ArchitectureDataStructureValidator.java
@@ -26,8 +26,8 @@ public class ArchitectureDataStructureValidator {
     }
 
     // TODO [TESTING]: Add tests
-        // Test 1: run this method, make sure some errors are caught (we're just testing that it's catching _something_, proving that it's using the schema validator, which is already tested)
-        // Test 2: run this method, make sure schema validator is called (but don't have strict assertions-- any call is fine)
+    // Test 1: run this method, make sure some errors are caught (we're just testing that it's catching _something_, proving that it's using the schema validator, which is already tested)
+    // Test 2: run this method, make sure schema validator is called (but don't have strict assertions-- any call is fine)
     public List<String> validate(File productArchitectureDirectory, String manifestFileName) throws IOException {
         File manifestFile = new File(productArchitectureDirectory.getAbsolutePath() + File.separator + manifestFileName);
         checkArgument(manifestFile.exists(), String.format("Product Architecture manifest file %s does not exist.", manifestFile.getAbsolutePath()));
@@ -41,5 +41,4 @@ public class ArchitectureDataStructureValidator {
             return schemaValidationMessages;
         }
     }
-
 }

--- a/src/main/java/net/trilogy/arch/validation/ModelReferenceValidator.java
+++ b/src/main/java/net/trilogy/arch/validation/ModelReferenceValidator.java
@@ -1,8 +1,8 @@
 package net.trilogy.arch.validation;
 
 import net.trilogy.arch.domain.ArchitectureDataStructure;
-import net.trilogy.arch.domain.c4.Entity;
 import net.trilogy.arch.domain.c4.C4Model;
+import net.trilogy.arch.domain.c4.Entity;
 
 import java.util.List;
 

--- a/src/main/java/net/trilogy/arch/validation/ModelValidator.java
+++ b/src/main/java/net/trilogy/arch/validation/ModelValidator.java
@@ -6,10 +6,9 @@ import java.util.List;
 
 import static java.util.Collections.emptyList;
 
-
 public class ModelValidator implements DataStructureValidator {
     @Override
-    public List<String> validate(ArchitectureDataStructure dataStructure){
+    public List<String> validate(ArchitectureDataStructure dataStructure) {
         return emptyList();
     }
 }

--- a/src/main/java/net/trilogy/arch/validation/architectureUpdate/ArchitectureUpdateValidator.java
+++ b/src/main/java/net/trilogy/arch/validation/architectureUpdate/ArchitectureUpdateValidator.java
@@ -41,18 +41,6 @@ public class ArchitectureUpdateValidator {
     private final Set<Tdd.Id> allTddIdsInDecisions;
     private final Set<Tdd.Id> allTddIdsInFunctionalRequirements;
 
-    public static ValidationResult validate(
-            ArchitectureUpdate architectureUpdateToValidate,
-            ArchitectureDataStructure architectureAfterUpdate,
-            ArchitectureDataStructure architectureBeforeUpdate) {
-
-        return new ArchitectureUpdateValidator(
-                architectureUpdateToValidate,
-                architectureAfterUpdate,
-                architectureBeforeUpdate
-        ).run();
-    }
-
     private ArchitectureUpdateValidator(
             ArchitectureUpdate architectureUpdate,
             ArchitectureDataStructure architectureAfterUpdate,
@@ -67,6 +55,18 @@ public class ArchitectureUpdateValidator {
         allTddIdsInDecisions = getAllTddIdsReferencedByDecisions();
         allTddIdsInFunctionalRequirements = getAllTddIdsReferencedByFunctionalRequirements();
         allFunctionalRequirementIds = getAllFunctionalRequirementIds();
+    }
+
+    public static ValidationResult validate(
+            ArchitectureUpdate architectureUpdateToValidate,
+            ArchitectureDataStructure architectureAfterUpdate,
+            ArchitectureDataStructure architectureBeforeUpdate) {
+
+        return new ArchitectureUpdateValidator(
+                architectureUpdateToValidate,
+                architectureAfterUpdate,
+                architectureBeforeUpdate
+        ).run();
     }
 
     private ValidationResult run() {

--- a/src/main/java/net/trilogy/arch/validation/architectureUpdate/ValidationErrorType.java
+++ b/src/main/java/net/trilogy/arch/validation/architectureUpdate/ValidationErrorType.java
@@ -18,14 +18,16 @@ public enum ValidationErrorType {
     INVALID_DELETED_COMPONENT_REFERENCE("Invalid Deleted Component Reference", TDD),
     DUPLICATE_TDD_ID("Duplicate TDD ID", TDD),
     DUPLICATE_COMPONENT_ID("Duplicate Component ID", TDD),
-    LINK_NOT_AVAILABLE ("Link value is N/A", TDD),
-    NO_PR_COMBINED_WITH_ANOTHER_TDD ("No-Pr is combined with another TDD", TDD),
+    LINK_NOT_AVAILABLE("Link value is N/A", TDD),
+    NO_PR_COMBINED_WITH_ANOTHER_TDD("No-Pr is combined with another TDD", TDD),
     AMBIGUOUS_TDD_CONTENT_REFERENCE("Ambiguous TDD content reference", TDD),
     MULTIPLE_TDD_CONTENT_FILES_REFERENCE_TDD("Multiple TDD content files associated with one TDD", TDD),
     OVERRIDDEN_BY_TDD_CONTENT_FILE("TDD content overridden by file", TDD);
 
-    @Getter private final String label;
-    @Getter private final ValidationStage stage;
+    @Getter
+    private final String label;
+    @Getter
+    private final ValidationStage stage;
 
     ValidationErrorType(String label, ValidationStage stage) {
         this.label = label;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
-  <Appenders>
-    <File name="arc-as-code-log" fileName="${sys:user.home}/.arch-as-code/arch-as-code.log" immediateFlush="true" append="true">
-      <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-    </File>
-  </Appenders>
-  <Loggers>
-    <Root level="info" additivity="false">
-      <AppenderRef ref="arc-as-code-log"/>
-    </Root>
-  </Loggers>
+    <Appenders>
+        <File name="arc-as-code-log"
+              fileName="${sys:user.home}/.arch-as-code/arch-as-code.log"
+              immediateFlush="true" append="true">
+            <PatternLayout
+                    pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Root level="info" additivity="false">
+            <AppenderRef ref="arc-as-code-log"/>
+        </Root>
+    </Loggers>
 </Configuration>

--- a/src/test/java/net/trilogy/arch/adapter/architectureUpdate/ArchitectureUpdateReaderTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/architectureUpdate/ArchitectureUpdateReaderTest.java
@@ -16,7 +16,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
 
 public class ArchitectureUpdateReaderTest {

--- a/src/test/java/net/trilogy/arch/adapter/architectureUpdate/ArchitectureUpdateWriterTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/architectureUpdate/ArchitectureUpdateWriterTest.java
@@ -19,7 +19,6 @@ public class ArchitectureUpdateWriterTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
 
-
     @Test
     public void shouldWriteAuAndTddContentToAuDirectory() throws Exception {
         // Given

--- a/src/test/java/net/trilogy/arch/adapter/git/GitInterfaceTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/git/GitInterfaceTest.java
@@ -1,6 +1,5 @@
 package net.trilogy.arch.adapter.git;
 
-
 import net.trilogy.arch.TestHelper;
 import net.trilogy.arch.adapter.architectureDataStructure.ArchitectureDataStructureObjectMapper;
 import org.apache.commons.io.FileUtils;
@@ -27,13 +26,12 @@ import static org.mockito.Mockito.when;
 public class GitInterfaceTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
+    private final String masterCommitTagName = "masterCommitTagName";
     private File repoDir;
     private File rootDir;
     private Path archPath;
     private String architectureAsString;
     private String masterCommitSha;
-    private final String masterCommitTagName = "masterCommitTagName";
 
     @After
     public void tearDown() throws Exception {
@@ -196,5 +194,4 @@ public class GitInterfaceTest {
                 .getBranch(archPath.toFile().getParentFile())
                 .equals(wantedBranch);
     }
-
 }

--- a/src/test/java/net/trilogy/arch/adapter/google/GoogleDocsApiInterfaceTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/google/GoogleDocsApiInterfaceTest.java
@@ -14,7 +14,9 @@ import java.io.IOException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(JUnitParamsRunner.class)
 public class GoogleDocsApiInterfaceTest {
@@ -22,7 +24,7 @@ public class GoogleDocsApiInterfaceTest {
     private GoogleDocsApiInterface apiInterface;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         mockedApi = mock(Docs.class);
         apiInterface = new GoogleDocsApiInterface(mockedApi);
     }

--- a/src/test/java/net/trilogy/arch/adapter/google/GoogleDocsAuthorizedApiFactoryTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/google/GoogleDocsAuthorizedApiFactoryTest.java
@@ -31,11 +31,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 
 /*
-* NOTE: Mockito Strict Stubbing is required. This test walks through
-*     the process of obtaining a google API connection by
-*     mocking each individual step. Strict stubbing acts as assertions
-*     throughout this process.
-*/
+ * NOTE: Mockito Strict Stubbing is required. This test walks through
+ *     the process of obtaining a google API connection by
+ *     mocking each individual step. Strict stubbing acts as assertions
+ *     throughout this process.
+ */
 @RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class GoogleDocsAuthorizedApiFactoryTest {
     @Rule
@@ -44,13 +44,12 @@ public class GoogleDocsAuthorizedApiFactoryTest {
     private final String CLIENT_ID = "client-id";
     private final String CLIENT_SECRET = "client-secret";
     private final List<String> SCOPES = List.of(DocsScopes.DOCUMENTS_READONLY);
-
+    private final NetHttpTransport httpTransport = new NetHttpTransport();
+    private final JacksonFactory jsonFactory = JacksonFactory.getDefaultInstance();
     private GoogleDocsAuthorizedApiFactory.AuthorizationCodeInstalledAppFactory mockedAuthorizationCodeInstalledAppFactory;
     private GoogleDocsAuthorizedApiFactory.CodeFlowBuilderFactory mockedCodeFlowBuilderFactory;
     private GoogleDocsAuthorizedApiFactory.DocsFactory mockedDocsFactory;
     private Path rootDir;
-    private final NetHttpTransport httpTransport = new NetHttpTransport();
-    private final JacksonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     @Before
     public void setUp() throws Exception {
@@ -154,5 +153,4 @@ public class GoogleDocsAuthorizedApiFactoryTest {
         Mockito.when(mockedCodeFlowBuilder.build()).thenReturn(mockedCodeFlow);
         return mockedCodeFlow;
     }
-
 }

--- a/src/test/java/net/trilogy/arch/adapter/google/GoogleDocumentReaderTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/google/GoogleDocumentReaderTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.when;
 @RunWith(JUnitParamsRunner.class)
 public class GoogleDocumentReaderTest {
 
-
     private final GoogleDocsApiInterface mockedApiInterface = mock(GoogleDocsApiInterface.class);
     private final GoogleDocumentReader reader = new GoogleDocumentReader(mockedApiInterface);
 
@@ -243,7 +242,6 @@ public class GoogleDocumentReaderTest {
                         "\n\n********* STATUS *********\n\n",
                 true, is(false)
         );
-
     }
 
     private JsonNode getJsonNodeFrom(String content) throws JsonProcessingException {

--- a/src/test/java/net/trilogy/arch/adapter/graphviz/GraphvizInterfaceTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/graphviz/GraphvizInterfaceTest.java
@@ -1,6 +1,5 @@
 package net.trilogy.arch.adapter.graphviz;
 
-
 import org.junit.Test;
 
 import java.nio.file.Files;

--- a/src/test/java/net/trilogy/arch/adapter/jira/JiraApiFactoryTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/jira/JiraApiFactoryTest.java
@@ -23,11 +23,11 @@ import static org.mockito.Mockito.when;
 public class JiraApiFactoryTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-    private FilesFacade mockedFiles;
     private final String expectedBaseUri = "BASE-URI/";
     private final String expectedGetStoryEndpoint = "GET-STORY-ENDPOINT/";
     private final String expectedBulkCreateEndpoint = "BULK-CREATE-ENDPOINT/";
     private final String expectedLinkPrefix = "LINK-PREFIX/";
+    private FilesFacade mockedFiles;
     private Path rootDir;
 
     @Before
@@ -63,7 +63,6 @@ public class JiraApiFactoryTest {
         collector.checkThat(jiraApi.getBulkCreateEndpoint(), equalTo(expectedBulkCreateEndpoint));
         collector.checkThat(jiraApi.getLinkPrefix(), equalTo(expectedLinkPrefix));
     }
-
 
     @Test
     public void shouldCreateCorrectClient() throws NoSuchAlgorithmException, IOException {

--- a/src/test/java/net/trilogy/arch/adapter/jira/JiraApiTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/jira/JiraApiTest.java
@@ -24,12 +24,23 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Flow;
 
-import static net.trilogy.arch.TestHelper.*;
+import static net.trilogy.arch.TestHelper.JSON_JIRA_CREATE_STORIES_REQUEST_EXPECTED_BODY;
+import static net.trilogy.arch.TestHelper.JSON_JIRA_CREATE_STORIES_RESPONSE_EXPECTED_BODY;
+import static net.trilogy.arch.TestHelper.JSON_JIRA_CREATE_STORIES_WITH_TDD_CONTENT_REQUEST_EXPECTED_BODY;
+import static net.trilogy.arch.TestHelper.JSON_JIRA_GET_EPIC;
+import static net.trilogy.arch.TestHelper.JSON_STRUCTURIZR_BIG_BANK;
+import static net.trilogy.arch.TestHelper.loadResource;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class JiraApiTest {
     @Rule
@@ -37,6 +48,11 @@ public class JiraApiTest {
 
     private HttpClient mockHttpClient;
     private JiraApi jiraApi;
+
+    @SuppressWarnings("unchecked")
+    private static HttpResponse<Object> mockedGenericHttpResponse() {
+        return (HttpResponse<Object>) mock(HttpResponse.class);
+    }
 
     @Before
     public void setUp() {
@@ -108,16 +124,11 @@ public class JiraApiTest {
 
             //THEN:
             fail("Exception not thrown.");
-        } catch( JiraApi.JiraApiException e ){
+        } catch (JiraApi.JiraApiException e) {
             collector.checkThat(e.getMessage(), equalTo("Unknown error occurred"));
             collector.checkThat(e.getCause(), is(instanceOf(Exception.class)));
             collector.checkThat(e.getResponse(), is(mockedResponse));
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static HttpResponse<Object> mockedGenericHttpResponse() {
-        return (HttpResponse<Object>) mock(HttpResponse.class);
     }
 
     @Test
@@ -133,7 +144,7 @@ public class JiraApiTest {
 
             //THEN:
             fail("Exception not thrown.");
-        } catch( JiraApi.JiraApiException e ){
+        } catch (JiraApi.JiraApiException e) {
             collector.checkThat(e.getMessage(), equalTo("Unknown error occurred"));
             collector.checkThat(e.getCause(), is(instanceOf(Exception.class)));
             collector.checkThat(e.getResponse(), is(mockedResponse));
@@ -153,7 +164,7 @@ public class JiraApiTest {
 
             //THEN:
             fail("Exception not thrown.");
-        } catch( JiraApi.JiraApiException e ){
+        } catch (JiraApi.JiraApiException e) {
             collector.checkThat(e.getMessage(), equalTo("Story \"A\" not found. URL: " + jiraApi.getBaseUri() + jiraApi.getGetStoryEndpoint() + "A"));
             collector.checkThat(e.getCause(), is(nullValue()));
             collector.checkThat(e.getResponse(), is(mockedResponse));
@@ -173,7 +184,7 @@ public class JiraApiTest {
 
             //THEN:
             fail("Exception not thrown.");
-        } catch( JiraApi.JiraApiException e ){
+        } catch (JiraApi.JiraApiException e) {
             collector.checkThat(e.getMessage(), equalTo("Failed to log into Jira. Please check your credentials."));
             collector.checkThat(e.getCause(), is(nullValue()));
             collector.checkThat(e.getResponse(), is(mockedResponse));
@@ -193,7 +204,7 @@ public class JiraApiTest {
 
             //THEN:
             fail("Exception not thrown.");
-        } catch( JiraApi.JiraApiException e ){
+        } catch (JiraApi.JiraApiException e) {
             collector.checkThat(e.getMessage(), equalTo("Failed to log into Jira. Please check your credentials."));
             collector.checkThat(e.getCause(), is(nullValue()));
             collector.checkThat(e.getResponse(), is(mockedResponse));
@@ -377,8 +388,8 @@ public class JiraApiTest {
     }
 
     /**
-     * Used for parsing request objects, to ensure in tests we're creating the right ones.
-     * See: https://stackoverflow.com/questions/59342963/how-to-test-java-net-http-java-11-requests-bodypublisher
+     * Used for parsing request objects, to ensure in tests we're creating the
+     * right ones. See: https://stackoverflow.com/questions/59342963/how-to-test-java-net-http-java-11-requests-bodypublisher
      */
     private static class HttpRequestParserForTests<T> implements Flow.Subscriber<T> {
         private final CountDownLatch latch = new CountDownLatch(1);
@@ -429,5 +440,4 @@ public class JiraApiTest {
             this.latch.countDown();
         }
     }
-
 }

--- a/src/test/java/net/trilogy/arch/adapter/jira/JiraTddTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/jira/JiraTddTest.java
@@ -15,7 +15,6 @@ public class JiraTddTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
 
-
     @Test
     public void shouldReturnInlinedTddContent() {
         JiraTdd tdd = new JiraTdd(

--- a/src/test/java/net/trilogy/arch/adapter/structurizr/StructurizrAdapterTest.java
+++ b/src/test/java/net/trilogy/arch/adapter/structurizr/StructurizrAdapterTest.java
@@ -1,6 +1,5 @@
 package net.trilogy.arch.adapter.structurizr;
 
-
 import com.structurizr.Workspace;
 import com.structurizr.api.StructurizrClient;
 import org.junit.Test;
@@ -8,7 +7,11 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class StructurizrAdapterTest {
 
@@ -63,5 +66,4 @@ public class StructurizrAdapterTest {
         // Then
         assertThat(result, equalTo(false));
     }
-
 }

--- a/src/test/java/net/trilogy/arch/annotators/ArchitectureUpdateAnnotatorTest.java
+++ b/src/test/java/net/trilogy/arch/annotators/ArchitectureUpdateAnnotatorTest.java
@@ -45,7 +45,7 @@ public class ArchitectureUpdateAnnotatorTest {
         ArchitectureUpdate au = ArchitectureUpdate.blank()
                 .toBuilder()
                 .tddContainersByComponent(
-                        List.of(new TddContainerByComponent(new Tdd.ComponentReference("13"), null,false, Map.of()))
+                        List.of(new TddContainerByComponent(new Tdd.ComponentReference("13"), null, false, Map.of()))
                 )
                 .build();
 
@@ -205,7 +205,7 @@ public class ArchitectureUpdateAnnotatorTest {
         );
         List<TddContainerByComponent> tddContainers = List.of(new TddContainerByComponent(
                         new Tdd.ComponentReference("13"),
-                null, false,
+                        null, false,
                         Map.of(
                                 new Tdd.Id("TDD 1.0"), new Tdd(null, null),
                                 new Tdd.Id("TDD 1.1"), new Tdd("text", null),

--- a/src/test/java/net/trilogy/arch/commands/mixin/DisplaysOutputMixinTest.java
+++ b/src/test/java/net/trilogy/arch/commands/mixin/DisplaysOutputMixinTest.java
@@ -3,18 +3,11 @@ package net.trilogy.arch.commands.mixin;
 import org.junit.Test;
 import picocli.CommandLine;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DisplaysOutputMixinTest {
-    static class TestCommand implements DisplaysOutputMixin {
-        @Override
-        public CommandLine.Model.CommandSpec getSpec() {
-            return null;
-        }
-    }
-
     @Test
     public void shouldMaskSecretValue() {
         CommandLine.Model.ArgSpec argSpec = mock(CommandLine.Model.ArgSpec.class);
@@ -46,5 +39,12 @@ public class DisplaysOutputMixinTest {
 
         var command = new TestCommand();
         assertEquals("<apiUser>:user123", command.maskedParamValue(argSpec));
+    }
+
+    static class TestCommand implements DisplaysOutputMixin {
+        @Override
+        public CommandLine.Model.CommandSpec getSpec() {
+            return null;
+        }
     }
 }

--- a/src/test/java/net/trilogy/arch/config/AppConfigTest.java
+++ b/src/test/java/net/trilogy/arch/config/AppConfigTest.java
@@ -6,9 +6,9 @@ import static org.junit.Assert.assertTrue;
 
 public class AppConfigTest {
 
-  @Test
-  public void shouldGetDefaultLogPath() {
-    String logPath = AppConfig.builder().build().getLogPath();
-    assertTrue( logPath.endsWith("/.arch-as-code/arch-as-code.log"));
-  }
+    @Test
+    public void shouldGetDefaultLogPath() {
+        String logPath = AppConfig.builder().build().getLogPath();
+        assertTrue(logPath.endsWith("/.arch-as-code/arch-as-code.log"));
+    }
 }

--- a/src/test/java/net/trilogy/arch/domain/DiffSetTest.java
+++ b/src/test/java/net/trilogy/arch/domain/DiffSetTest.java
@@ -94,11 +94,9 @@ public class DiffSetTest {
         var outsideSystem = getSystemDiff("other-system");
         var containerOutsideSystem = getContainerDiff("other-container", "other-system");
 
-
         var relWithSystem = getRelationshipDiff("1", getId(container), getId(outsideSystem));
         var relWithPerson = getRelationshipDiff("2", getId(personOutsideSystem), getId(container));
         var relWithContainer = getRelationshipDiff("3", getId(containerOutsideSystem), getId(container));
-
 
         // WHEN
         var diffset = getDiffSetWithAllTypesOfDiffsPlus(

--- a/src/test/java/net/trilogy/arch/domain/DiffTest.java
+++ b/src/test/java/net/trilogy/arch/domain/DiffTest.java
@@ -14,7 +14,9 @@ import java.util.HashMap;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
 public class DiffTest {
@@ -140,10 +142,14 @@ public class DiffTest {
 
     @EqualsAndHashCode(callSuper = false)
     private static class Thing extends DiffableWithRelatedTdds implements Diffable {
-        @Getter private final String id;
-        @Getter private final String name;
-        @Getter private final C4Type type;
-        @Getter @Setter
+        @Getter
+        private final String id;
+        @Getter
+        private final String name;
+        @Getter
+        private final C4Type type;
+        @Getter
+        @Setter
         private String[] relatedTo = new String[0];
 
         public Thing(String id) {

--- a/src/test/java/net/trilogy/arch/domain/DocumentationImageTest.java
+++ b/src/test/java/net/trilogy/arch/domain/DocumentationImageTest.java
@@ -11,7 +11,6 @@ import java.nio.file.Files;
 
 import static org.hamcrest.Matchers.equalTo;
 
-
 public class DocumentationImageTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();

--- a/src/test/java/net/trilogy/arch/domain/DocumentationSectionTest.java
+++ b/src/test/java/net/trilogy/arch/domain/DocumentationSectionTest.java
@@ -14,7 +14,6 @@ import static net.trilogy.arch.domain.DocumentationSection.Format.MARKDOWN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-
 public class DocumentationSectionTest {
     @Test
     public void shouldReturnStructurizrFormat() {
@@ -71,6 +70,5 @@ public class DocumentationSectionTest {
         assertThat(unorderedDoc.getFileName(), equalTo("UnorderedTitle.md"));
         assertThat(orderedNoExtension.getFileName(), equalTo("2_NoExtension"));
         assertThat(unorderedNoExtension.getFileName(), equalTo("NoExtension"));
-
     }
 }

--- a/src/test/java/net/trilogy/arch/domain/architectureUpdate/ArchitectureUpdateTest.java
+++ b/src/test/java/net/trilogy/arch/domain/architectureUpdate/ArchitectureUpdateTest.java
@@ -1,11 +1,11 @@
 package net.trilogy.arch.domain.architectureUpdate;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Test;
 
 import java.util.List;
 
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ArchitectureUpdateTest {
 
@@ -15,11 +15,11 @@ public class ArchitectureUpdateTest {
         final var storyToChange = FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 2", "OLD JIRA LINK 2")).build();
 
         final var originalAu = getAuWithStories(
-            List.of(
-                FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 1", "OLD JIRA LINK 1")).build(),
-                storyToChange,
-                FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 3", "OLD JIRA LINK 3")).build()
-            )
+                List.of(
+                        FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 1", "OLD JIRA LINK 1")).build(),
+                        storyToChange,
+                        FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 3", "OLD JIRA LINK 3")).build()
+                )
         );
 
         // WHEN:
@@ -27,11 +27,11 @@ public class ArchitectureUpdateTest {
 
         // THEN:
         final var expected = getAuWithStories(
-            List.of(
-                FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 1", "OLD JIRA LINK 1")).build(),
-                FeatureStory.blank().toBuilder().jira(new Jira("NEW JIRA TICKET", "NEW JIRA LINK")).build(),
-                FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 3", "OLD JIRA LINK 3")).build()
-            )
+                List.of(
+                        FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 1", "OLD JIRA LINK 1")).build(),
+                        FeatureStory.blank().toBuilder().jira(new Jira("NEW JIRA TICKET", "NEW JIRA LINK")).build(),
+                        FeatureStory.blank().toBuilder().jira(new Jira("OLD JIRA TICKET 3", "OLD JIRA LINK 3")).build()
+                )
         );
 
         assertThat(actual, equalTo(expected));

--- a/src/test/java/net/trilogy/arch/domain/architectureUpdate/TddContentTest.java
+++ b/src/test/java/net/trilogy/arch/domain/architectureUpdate/TddContentTest.java
@@ -19,7 +19,6 @@ public class TddContentTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
 
-
     @Test
     public void shouldIdentifyAllowedFileTypes() throws IOException {
         File tempMarkdown = Files.createTempFile("markdown", ".md").toFile();
@@ -46,7 +45,6 @@ public class TddContentTest {
         collector.checkThat(TddContent.isTddContentName(tddMarkdown), equalTo(true));
         collector.checkThat(TddContent.isTddContentName(tddText), equalTo(true));
         collector.checkThat(TddContent.isTddContentName(arbitraryIdText), equalTo(true));
-
     }
 
     @Test

--- a/src/test/java/net/trilogy/arch/domain/c4/C4PathTest.java
+++ b/src/test/java/net/trilogy/arch/domain/c4/C4PathTest.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
-
 public class C4PathTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
@@ -83,7 +82,6 @@ public class C4PathTest {
 
         C4Path componentPath = C4Path.buildPath(buildComponent("component/3/container/2/system/1", container));
 
-
         collector.checkThat(personPath.type(), equalTo(C4Type.PERSON));
         collector.checkThat(personPath.name(), equalTo("person/1"));
         collector.checkThat(personPath.getPath(), equalTo("@person\\/1"));
@@ -108,7 +106,6 @@ public class C4PathTest {
         C4Path containerPath = C4Path.buildPath(buildContainer("container.1"));
         C4Path componentPath = C4Path.buildPath(buildComponent("component.1"));
 
-
         collector.checkThat(personPath.type(), equalTo(C4Type.PERSON));
         collector.checkThat(personPath.name(), equalTo("person.1"));
         collector.checkThat(personPath.getPath(), equalTo("@person.1"));
@@ -132,7 +129,6 @@ public class C4PathTest {
         C4Path systemPath = C4Path.buildPath(buildSoftwareSystem("system 1"));
         C4Path containerPath = C4Path.buildPath(buildContainer("container 1"));
         C4Path componentPath = C4Path.buildPath(buildComponent("component 1"));
-
 
         collector.checkThat(personPath.type(), equalTo(C4Type.PERSON));
         collector.checkThat(personPath.name(), equalTo("person 1"));
@@ -308,7 +304,6 @@ public class C4PathTest {
         C4Path path = C4Path.path("c4://sys1/container1");
         path.componentPath();
     }
-
 
     private Component buildComponent(String componentName) {
         return buildComponent(componentName, null);

--- a/src/test/java/net/trilogy/arch/e2e/DiffCommandE2ETest.java
+++ b/src/test/java/net/trilogy/arch/e2e/DiffCommandE2ETest.java
@@ -22,9 +22,14 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 
 import static net.trilogy.arch.TestHelper.execute;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DiffCommandE2ETest {
     @Rule

--- a/src/test/java/net/trilogy/arch/e2e/ImportCommandE2ETest.java
+++ b/src/test/java/net/trilogy/arch/e2e/ImportCommandE2ETest.java
@@ -31,13 +31,11 @@ import static org.mockito.Mockito.when;
 public class ImportCommandE2ETest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
-    private Path tempProductDirectory;
-
     final PrintStream originalOut = System.out;
     final PrintStream originalErr = System.err;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    private Path tempProductDirectory;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/net/trilogy/arch/e2e/InitializeCommandE2ETest.java
+++ b/src/test/java/net/trilogy/arch/e2e/InitializeCommandE2ETest.java
@@ -1,6 +1,5 @@
 package net.trilogy.arch.e2e;
 
-
 import net.trilogy.arch.Application;
 import net.trilogy.arch.facade.FilesFacade;
 import org.junit.After;
@@ -18,21 +17,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.trilogy.arch.TestHelper.execute;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-
 
 public class InitializeCommandE2ETest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
-    private Path tempProductDirectory;
-
     final PrintStream originalOut = System.out;
     final PrintStream originalErr = System.err;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    private Path tempProductDirectory;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/net/trilogy/arch/e2e/ListComponentsCommandE2ETest.java
+++ b/src/test/java/net/trilogy/arch/e2e/ListComponentsCommandE2ETest.java
@@ -14,18 +14,18 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 
 import static net.trilogy.arch.TestHelper.execute;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class ListComponentsCommandE2ETest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
-    private File rootDir;
-
     final PrintStream originalOut = System.out;
     final PrintStream originalErr = System.err;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    private File rootDir;
 
     @Before
     public void setUp() {
@@ -69,7 +69,7 @@ public class ListComponentsCommandE2ETest {
     public void shouldOutputComponentsListFilteredBySearchString() throws Exception {
         initFileForTest("allValidSchema.yml");
 
-        int status = TestHelper.execute("list-components",  "-s password", rootDir.getAbsolutePath());
+        int status = TestHelper.execute("list-components", "-s password", rootDir.getAbsolutePath());
 
         collector.checkThat(status, equalTo(0));
         collector.checkThat(out.toString(), equalTo(
@@ -121,5 +121,4 @@ public class ListComponentsCommandE2ETest {
         collector.checkThat(out.toString(), equalTo(""));
         collector.checkThat(err.toString(), containsString("Unable to load architecture\nError: java.nio.file.NoSuchFileException"));
     }
-
 }

--- a/src/test/java/net/trilogy/arch/e2e/ParentCommandE2ETest.java
+++ b/src/test/java/net/trilogy/arch/e2e/ParentCommandE2ETest.java
@@ -13,7 +13,6 @@ import static net.trilogy.arch.TestHelper.execute;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-
 public class ParentCommandE2ETest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();

--- a/src/test/java/net/trilogy/arch/e2e/PublishCommandE2ETest.java
+++ b/src/test/java/net/trilogy/arch/e2e/PublishCommandE2ETest.java
@@ -17,9 +17,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.trilogy.arch.TestHelper.execute;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PublishCommandE2ETest {
     @Rule

--- a/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuAnnotateCommandTest.java
+++ b/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuAnnotateCommandTest.java
@@ -19,26 +19,28 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuAnnotateCommandTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
-    Path rootPath;
-    Path originalAuWithComponentsDirectoryPath;
-    Path originalAuWithoutComponentsDirectoryPath;
-    Path originalAuWithTddContentsDirectoryPath;
-
-    Path changedAuWithComponentsDirectoryPath;
-    Path changedAuWithoutComponentsDirectoryPath;
-    Path changedAuWithTddContentsDirectoryPath;
-
     final PrintStream originalOut = System.out;
     final PrintStream originalErr = System.err;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    Path rootPath;
+    Path originalAuWithComponentsDirectoryPath;
+    Path originalAuWithoutComponentsDirectoryPath;
+    Path originalAuWithTddContentsDirectoryPath;
+    Path changedAuWithComponentsDirectoryPath;
+    Path changedAuWithoutComponentsDirectoryPath;
+    Path changedAuWithTddContentsDirectoryPath;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuNewCommandTest.java
+++ b/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuNewCommandTest.java
@@ -32,24 +32,29 @@ import java.util.Objects;
 import static net.trilogy.arch.TestHelper.execute;
 import static net.trilogy.arch.commands.architectureUpdate.AuCommand.ARCHITECTURE_UPDATES_ROOT_FOLDER;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class AuNewCommandTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
+    final PrintStream originalOut = System.out;
+    final PrintStream originalErr = System.err;
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    final ByteArrayOutputStream err = new ByteArrayOutputStream();
     private GoogleDocsApiInterface googleDocsApiMock;
     private FilesFacade filesFacadeSpy;
     private GitInterface gitInterfaceSpy;
     private Application app;
     private File rootDir;
-
-    final PrintStream originalOut = System.out;
-    final PrintStream originalErr = System.err;
-    final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    final ByteArrayOutputStream err = new ByteArrayOutputStream();
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuPublishStoriesCommandTest.java
+++ b/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuPublishStoriesCommandTest.java
@@ -50,19 +50,16 @@ import static org.mockito.Mockito.when;
 public class AuPublishStoriesCommandTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
-    private File rootDir;
-    private Path testCloneDirectory;
-
-    private JiraApi mockedJiraApi;
-    private Application app;
-    private FilesFacade spiedFilesFacade;
-    private GitInterface mockedGitInterface;
-
     final PrintStream originalOut = System.out;
     final PrintStream originalErr = System.err;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    private File rootDir;
+    private Path testCloneDirectory;
+    private JiraApi mockedJiraApi;
+    private Application app;
+    private FilesFacade spiedFilesFacade;
+    private GitInterface mockedGitInterface;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuValidateCommandTest.java
+++ b/src/test/java/net/trilogy/arch/e2e/architectureUpdate/AuValidateCommandTest.java
@@ -16,20 +16,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static net.trilogy.arch.TestHelper.execute;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class AuValidateCommandTest {
     @Rule
     public final ErrorCollector collector = new ErrorCollector();
-
-    private File rootDir;
-    private Path auDir;
-    private Git git;
-
     final PrintStream originalOut = System.out;
     final PrintStream originalErr = System.err;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
+    private File rootDir;
+    private Path auDir;
+    private Git git;
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/net/trilogy/arch/integration/SchemaValidationTest.java
+++ b/src/test/java/net/trilogy/arch/integration/SchemaValidationTest.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-
 public class SchemaValidationTest {
 
     @Test
@@ -60,12 +59,10 @@ public class SchemaValidationTest {
                 ));
     }
 
-
     private Set<ValidationMessage> getSchemaValidationMessages(String yamlFileName) throws FileNotFoundException {
         File validationRoot = new File(getClass().getResource(TestHelper.ROOT_PATH_TO_TEST_VALIDATION).getPath());
         File yamlFile = new File(validationRoot + File.separator + yamlFileName);
         return new SchemaValidator()
                 .validateArchitectureDocument(new FileInputStream(yamlFile));
     }
-
 }

--- a/src/test/java/net/trilogy/arch/publish/ArchitectureDataStructurePublisherTest.java
+++ b/src/test/java/net/trilogy/arch/publish/ArchitectureDataStructurePublisherTest.java
@@ -12,7 +12,10 @@ import java.io.File;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ArchitectureDataStructurePublisherTest {
     @Test

--- a/src/test/java/net/trilogy/arch/services/DiffToDotCalculatorTest.java
+++ b/src/test/java/net/trilogy/arch/services/DiffToDotCalculatorTest.java
@@ -13,7 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static net.trilogy.arch.ArchitectureDataStructureHelper.*;
+import static net.trilogy.arch.ArchitectureDataStructureHelper.createComponent;
+import static net.trilogy.arch.ArchitectureDataStructureHelper.createContainer;
+import static net.trilogy.arch.ArchitectureDataStructureHelper.createPerson;
+import static net.trilogy.arch.ArchitectureDataStructureHelper.createRelationship;
+import static net.trilogy.arch.ArchitectureDataStructureHelper.createSystem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -236,7 +240,7 @@ public class DiffToDotCalculatorTest {
     public void shouldGenerateUrlIfHasContainerChild() {
         var diff = new Diff(
                 new DiffableEntity(createPerson("5")),
-                Set.of( new DiffableEntity(createContainer("4", "3")) ),
+                Set.of(new DiffableEntity(createContainer("4", "3"))),
                 null,
                 null
         );
@@ -248,7 +252,7 @@ public class DiffToDotCalculatorTest {
     public void shouldGenerateUrlIfHasComponentChild() {
         var diff = new Diff(
                 new DiffableEntity(createPerson("5")),
-                Set.of( new DiffableEntity(createComponent("4", "3")) ),
+                Set.of(new DiffableEntity(createComponent("4", "3"))),
                 null,
                 null
         );
@@ -257,7 +261,7 @@ public class DiffToDotCalculatorTest {
     }
 
     @Test
-    public void shouldCalculateTooltipForRelationships(){
+    public void shouldCalculateTooltipForRelationships() {
         var p1Diff = new Diff(new DiffableEntity(createPerson("1")), null);
         var p2Diff = new Diff(null, new DiffableEntity(createPerson("2")));
         var rel = new DiffableRelationship("1", createRelationship("r", "2"));
@@ -336,7 +340,7 @@ public class DiffToDotCalculatorTest {
         var actual = DiffToDotCalculator.toDot("Tdds", diff);
 
         var expected = String.join("\n",
-     "digraph \"Tdds\" {",
+                "digraph \"Tdds\" {",
                 "    graph [rankdir=LR];",
                 "",
                 "    \"tdds\" [label=<<TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\"><TR><TD><TABLE CELLBORDER=\"0\" CELLSPACING=\"0\"><TR><TD align=\"text\">TDD 1.1 - Some text<br align=\"left\" /></TD></TR></TABLE></TD></TR></TABLE>>, color=black, fontcolor=black, shape=plaintext];",
@@ -349,5 +353,4 @@ public class DiffToDotCalculatorTest {
     private void appendln(StringBuilder builder, String line) {
         builder.append(line).append("\n");
     }
-
 }

--- a/src/test/java/net/trilogy/arch/transformation/LocationTransformerTest.java
+++ b/src/test/java/net/trilogy/arch/transformation/LocationTransformerTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-
 public class LocationTransformerTest {
 
     @Test

--- a/src/test/java/net/trilogy/arch/transformation/enhancer/DocumentationEnhancerTest.java
+++ b/src/test/java/net/trilogy/arch/transformation/enhancer/DocumentationEnhancerTest.java
@@ -23,7 +23,9 @@ import java.util.stream.Collectors;
 
 import static net.trilogy.arch.TestHelper.ROOT_PATH_TO_TEST_PRODUCT_DOCUMENTATION;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -36,6 +38,13 @@ public class DocumentationEnhancerTest {
     final PrintStream originalErr = System.err;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+    private static <T> T first(final Collection<T> first) {
+        final Iterator<T> it = first.iterator();
+        if (!it.hasNext())
+            throw new IllegalStateException("No first element");
+        return it.next();
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -122,11 +131,5 @@ public class DocumentationEnhancerTest {
         collector.checkThat(images.size(), equalTo(1));
         final Image image = first(images);
         collector.checkThat(image.getName(), equalTo("devfactory.png"));
-    }
-
-    private static <T> T first(final Collection<T> first) {
-        final Iterator<T> it = first.iterator();
-        if (!it.hasNext()) throw new IllegalStateException("No first element");
-        return it.next();
     }
 }


### PR DESCRIPTION
Uses IntelliJ default formatting with this change:
1) Only keep 1 extra newline, not 2

Point of the PR:
- Use common formatting among us to avoid painful merge conflicts
- IntelliJ defaults seem "good enough"
- Consistency makes reading easier

Discovered:
- Some tests failed after reformatting JSON in `src/test/resources`.  This PR *does not* include those reformattings; only `src/test/java` is changed.  This implies we are doing some literal string comparisons rather than comparing the JSON semantically.  This is a _smell_